### PR TITLE
Reset search filters when user searches for dataset from dashboard (using URL) #5881

### DIFF
--- a/frontend/src/app/+research/+tab-search/tab-search.component.ts
+++ b/frontend/src/app/+research/+tab-search/tab-search.component.ts
@@ -147,6 +147,10 @@ export class TabSearchComponent implements OnInit {
     });
 
     this.route.params.subscribe((data) => {
+      // if the query came from URL, then reset the filters
+      if (data.q !== undefined) {
+        this.resetSearchField();
+      }
       this.form.setValue({
         type: data.type ?? "selectDocuments",
         query: data.q ?? "",


### PR DESCRIPTION
I fixed it by checking parameter 'q' from the route, this will work not only with dashboard but whenever the search parameter in the route is used. 