### PR TITLE
Bug/5980 fix document history

### DIFF
--- a/frontend/src/app/+form/dialogs/history/history.plugin.ts
+++ b/frontend/src/app/+form/dialogs/history/history.plugin.ts
@@ -185,7 +185,6 @@ export class HistoryPlugin extends Plugin {
         eventId: this.eventIdPrevious,
         pos: 200,
         active: false,
-        hiddenMenu: [],
       },
       {
         id: "toolBtnNextInHistory",
@@ -194,7 +193,6 @@ export class HistoryPlugin extends Plugin {
         eventId: this.eventIdNext,
         pos: 210,
         active: false,
-        hiddenMenu: [],
       },
     ];
     buttons.forEach((button) => this.formToolbarService.addButton(button));
@@ -324,7 +322,6 @@ export class HistoryPlugin extends Plugin {
     });
 
     this.formToolbarService.updateHiddenMenu("toolBtnNextInHistory", history);
-    this.formToolbarService.activateHiddenMenu("toolBtnNextInHistory");
     trigger.openMenu();
   }
 
@@ -349,7 +346,6 @@ export class HistoryPlugin extends Plugin {
       "toolBtnPreviousInHistory",
       history,
     );
-    this.formToolbarService.activateHiddenMenu("toolBtnPreviousInHistory");
     trigger.openMenu();
   }
 

--- a/frontend/src/app/+form/dialogs/history/history.plugin.ts
+++ b/frontend/src/app/+form/dialogs/history/history.plugin.ts
@@ -279,6 +279,7 @@ export class HistoryPlugin extends Plugin {
         explicitActiveNode: new ShortTreeNode(<number>item.id, item.title),
       });
     }
+    return navigated;
   }
 
   private handleButtonState() {
@@ -302,7 +303,11 @@ export class HistoryPlugin extends Plugin {
     });
     this.handleButtonState();
   }
-
+  /**
+   * Initializes and opens a mat-menu with clickable list of next nodes in history
+   * @param trigger
+   * @private
+   */
   private handleListNext(trigger?: MatMenuTrigger) {
     const history = this.stack.slice(this.pointer + 1).map((item) => {
       return {
@@ -317,7 +322,7 @@ export class HistoryPlugin extends Plugin {
   }
 
   /**
-   * Initiates and opens a mat-menu with clickable list of previously visited nodes
+   * Initializes and opens a mat-menu with clickable list of previously visited nodes
    * @param trigger
    * @private
    */
@@ -345,25 +350,28 @@ export class HistoryPlugin extends Plugin {
    * @param item
    * @private
    */
-  private handleHistoryPreviousSelect(item: any) {
-    console.log("Index:" + item.data.index);
+  private async handleHistoryPreviousSelect(item: any) {
     const currentOpenedDocumentId = this.tree.getOpenedDocument()?.id;
     if (currentOpenedDocumentId !== item.data.data.id) {
-      this.pointer = this.pointer - item.data.index - 1;
-      this.ignoreNextPush = true;
-      this.gotoNode(item.data.data);
-      this.handleButtonState();
+      const navigated = await this.gotoNode(item.data.data);
+      if (navigated) {
+        this.pointer = this.pointer - item.data.index - 1;
+        this.ignoreNextPush = true;
+        this.handleButtonState();
+      }
       return;
     }
   }
 
-  private handleHistoryNextSelect(item: any) {
+  private async handleHistoryNextSelect(item: any) {
     const currentOpenedDocumentId = this.tree.getOpenedDocument()?.id;
     if (currentOpenedDocumentId !== item.data.data.id) {
-      this.ignoreNextPush = true;
-      this.pointer = this.pointer + item.data.index + 1;
-      this.gotoNode(item.data.data);
-      this.handleButtonState();
+      const navigated = await this.gotoNode(item.data.data);
+      if (navigated) {
+        this.ignoreNextPush = true;
+        this.pointer = this.pointer + item.data.index + 1;
+        this.handleButtonState();
+      }
       return;
     }
   }

--- a/frontend/src/app/+form/dialogs/history/history.plugin.ts
+++ b/frontend/src/app/+form/dialogs/history/history.plugin.ts
@@ -153,9 +153,9 @@ export class HistoryPlugin extends Plugin {
       this.docEvents
         .onEvent(this.eventIdNext)
         .subscribe(() => this.handleNext()),
-      this.docEvents
-        .onEvent(this.eventIdPrevious)
-        .subscribe(() => this.handlePrevious()),
+      this.docEvents.onEvent(this.eventIdPrevious).subscribe(() => {
+        this.handlePrevious();
+      }),
       this.docEvents
         .onEvent(`${this.eventIdPrevious}_LONGPRESS`)
         .subscribe((event) => {
@@ -213,7 +213,7 @@ export class HistoryPlugin extends Plugin {
     }
   }
 
-  private handleNext() {
+  private async handleNext() {
     // prevent too fast clicks
     if (this.ignoreNextPush) {
       return;
@@ -226,15 +226,17 @@ export class HistoryPlugin extends Plugin {
     // popup.close(this.popupMenu);
 
     const node = this.stack[this.pointer + 1];
-    this.ignoreNextPush = true;
-    if (this.hasNext()) {
-      this.pointer++;
+
+    const navigated = await this.gotoNode(node);
+    if (navigated) {
+      if (this.hasNext()) {
+        this.pointer++;
+      }
     }
-    this.gotoNode(node);
     this.handleButtonState();
   }
 
-  private handlePrevious() {
+  private async handlePrevious() {
     // prevent too fast clicks
     if (this.ignoreNextPush) {
       return;
@@ -253,11 +255,13 @@ export class HistoryPlugin extends Plugin {
     }
 
     const node = this.stack[this.pointer - 1];
-    this.ignoreNextPush = true;
-    if (this.pointer > 0) {
-      this.pointer--;
+
+    const navigated = await this.gotoNode(node);
+    if (navigated) {
+      if (this.pointer > 0) {
+        this.pointer--;
+      }
     }
-    this.gotoNode(node);
     this.handleButtonState();
   }
 
@@ -275,6 +279,7 @@ export class HistoryPlugin extends Plugin {
       { id: item._uuid },
     ]);
     if (navigated) {
+      this.ignoreNextPush = true;
       this.treeStore.update({
         explicitActiveNode: new ShortTreeNode(<number>item.id, item.title),
       });
@@ -303,6 +308,7 @@ export class HistoryPlugin extends Plugin {
     });
     this.handleButtonState();
   }
+
   /**
    * Initializes and opens a mat-menu with clickable list of next nodes in history
    * @param trigger
@@ -318,11 +324,12 @@ export class HistoryPlugin extends Plugin {
     });
 
     this.formToolbarService.updateHiddenMenu("toolBtnNextInHistory", history);
+    this.formToolbarService.activateHiddenMenu("toolBtnNextInHistory");
     trigger.openMenu();
   }
 
   /**
-   * Initializes and opens a mat-menu with clickable list of previously visited nodes
+   * Initializes and opens a mat-menu with clickable list of previously visited nodes upon long press
    * @param trigger
    * @private
    */
@@ -342,6 +349,7 @@ export class HistoryPlugin extends Plugin {
       "toolBtnPreviousInHistory",
       history,
     );
+    this.formToolbarService.activateHiddenMenu("toolBtnPreviousInHistory");
     trigger.openMenu();
   }
 
@@ -356,19 +364,22 @@ export class HistoryPlugin extends Plugin {
       const navigated = await this.gotoNode(item.data.data);
       if (navigated) {
         this.pointer = this.pointer - item.data.index - 1;
-        this.ignoreNextPush = true;
         this.handleButtonState();
       }
       return;
     }
   }
 
+  /**
+   * Handles the selection of a node from next history list
+   * @param item
+   * @private
+   */
   private async handleHistoryNextSelect(item: any) {
     const currentOpenedDocumentId = this.tree.getOpenedDocument()?.id;
     if (currentOpenedDocumentId !== item.data.data.id) {
       const navigated = await this.gotoNode(item.data.data);
       if (navigated) {
-        this.ignoreNextPush = true;
         this.pointer = this.pointer + item.data.index + 1;
         this.handleButtonState();
       }

--- a/frontend/src/app/+form/form-shared/toolbar/form-toolbar.component.html
+++ b/frontend/src/app/+form/form-shared/toolbar/form-toolbar.component.html
@@ -6,7 +6,14 @@
                     mat-button
                     long-press
                     class="standard-toolbar-button"
-                    [matMenuTriggerFor]="button.hiddenMenu ? hiddenMenu : null"
+                    [matMenuTriggerFor]="
+                        button.hiddenMenu &&
+                        button.hiddenMenu.length > 0 &&
+                        button.showHiddenMenu
+                            ? hiddenMenu
+                            : null
+                    "
+                    (menuClosed)="button.showHiddenMenu = false"
                     #hiddenMenuTrigger="matMenuTrigger"
                     [attr.data-cy]="'toolbar_' + button.eventId"
                     (longPress)="

--- a/frontend/src/app/+form/form-shared/toolbar/form-toolbar.component.html
+++ b/frontend/src/app/+form/form-shared/toolbar/form-toolbar.component.html
@@ -6,14 +6,8 @@
                     mat-button
                     long-press
                     class="standard-toolbar-button"
-                    [matMenuTriggerFor]="
-                        button.hiddenMenu &&
-                        button.hiddenMenu.length > 0 &&
-                        button.showHiddenMenu
-                            ? hiddenMenu
-                            : null
-                    "
-                    (menuClosed)="button.showHiddenMenu = false"
+                    [matMenuTriggerFor]="button.hiddenMenu ? hiddenMenu : null"
+                    (menuClosed)="removeHiddenMenu(button)"
                     #hiddenMenuTrigger="matMenuTrigger"
                     [attr.data-cy]="'toolbar_' + button.eventId"
                     (longPress)="
@@ -30,8 +24,8 @@
                     <mat-icon
                         class="material-icons-outlined"
                         [svgIcon]="button.matSvgVariable"
-                        >{{ button.matIconVariable }}</mat-icon
-                    >
+                        >{{ button.matIconVariable }}
+                    </mat-icon>
                 </button>
             }
             <mat-menu #hiddenMenu="matMenu">
@@ -71,8 +65,8 @@
                     <mat-icon
                         class="material-icons-outlined"
                         [svgIcon]="button.matSvgVariable"
-                        >{{ button.matIconVariable }}</mat-icon
-                    >
+                        >{{ button.matIconVariable }}
+                    </mat-icon>
                     <mat-icon class="animated" [class.flipIt]="menu[button.id]"
                         >arrow_drop_down
                     </mat-icon>

--- a/frontend/src/app/+form/form-shared/toolbar/form-toolbar.component.ts
+++ b/frontend/src/app/+form/form-shared/toolbar/form-toolbar.component.ts
@@ -71,4 +71,12 @@ export class FormToolbarComponent implements OnInit {
   restoreFocus() {
     if (this.currentFocusedEl) this.currentFocusedEl.focus();
   }
+
+  // Set timeout to avoid flash rendering empty hidden menu after selection
+  // https://github.com/angular/components/issues/11929
+  removeHiddenMenu(button) {
+    setTimeout(() => {
+      button.hiddenMenu = null;
+    }, 500);
+  }
 }

--- a/frontend/src/app/+form/form-shared/toolbar/form-toolbar.service.ts
+++ b/frontend/src/app/+form/form-shared/toolbar/form-toolbar.service.ts
@@ -46,7 +46,6 @@ export interface ToolbarItem extends DefaultToolbarItem {
   isPrimary?: boolean;
   menu?: ToolbarMenuItem[];
   hiddenMenu?: ToolbarMenuItem[];
-  showHiddenMenu?: boolean;
 }
 
 export interface Separator extends DefaultToolbarItem {
@@ -153,13 +152,6 @@ export class FormToolbarService {
     const button = <ToolbarItem>this.getButtonById(id);
     if (button) {
       button.hiddenMenu = hiddenMenu;
-    }
-  }
-
-  activateHiddenMenu(id: string) {
-    const button = <ToolbarItem>this.getButtonById(id);
-    if (button) {
-      button.showHiddenMenu = true;
     }
   }
 }

--- a/frontend/src/app/+form/form-shared/toolbar/form-toolbar.service.ts
+++ b/frontend/src/app/+form/form-shared/toolbar/form-toolbar.service.ts
@@ -46,6 +46,7 @@ export interface ToolbarItem extends DefaultToolbarItem {
   isPrimary?: boolean;
   menu?: ToolbarMenuItem[];
   hiddenMenu?: ToolbarMenuItem[];
+  showHiddenMenu?: boolean;
 }
 
 export interface Separator extends DefaultToolbarItem {
@@ -121,14 +122,7 @@ export class FormToolbarService {
     const button: any = document.getElementsByClassName(className)?.item(0);
     if (button) button.click();
   }
-  longPressItemMenu(className: string) {
-    const button: any = document.getElementsByClassName(className)?.item(0);
-    if (button) {
-      button.dispatchEvent(new Event("mousedown"));
-      button.dispatchEvent(new Event("mouseup"));
-      setTimeout(() => {}, 600);
-    }
-  }
+
   /**
    * Set the state of a toolbar button to enabled or disabled.
    * @param id
@@ -159,6 +153,13 @@ export class FormToolbarService {
     const button = <ToolbarItem>this.getButtonById(id);
     if (button) {
       button.hiddenMenu = hiddenMenu;
+    }
+  }
+
+  activateHiddenMenu(id: string) {
+    const button = <ToolbarItem>this.getButtonById(id);
+    if (button) {
+      button.showHiddenMenu = true;
     }
   }
 }

--- a/frontend/src/app/directives/longPress.directive.ts
+++ b/frontend/src/app/directives/longPress.directive.ts
@@ -46,11 +46,14 @@ export class LongPressDirective {
       this.longPress.emit(event);
       this.longPressHandled = true;
     }, 500);
+    return;
   }
 
-  @HostListener("mouseup")
-  @HostListener("touchend")
+  @HostListener("mouseup", ["$event"])
+  @HostListener("touchend", ["$event"])
   onMouseUp(event: Event) {
+    event.preventDefault();
+    event.stopPropagation();
     if (this.longPressTimeout) {
       clearTimeout(this.longPressTimeout);
       if (!this.longPressHandled) this.shortClick.emit(event);

--- a/frontend/src/app/directives/longPress.directive.ts
+++ b/frontend/src/app/directives/longPress.directive.ts
@@ -49,11 +49,9 @@ export class LongPressDirective {
     return;
   }
 
-  @HostListener("mouseup", ["$event"])
-  @HostListener("touchend", ["$event"])
+  @HostListener("mouseup")
+  @HostListener("touchend")
   onMouseUp(event: Event) {
-    event.preventDefault();
-    event.stopPropagation();
     if (this.longPressTimeout) {
       clearTimeout(this.longPressTimeout);
       if (!this.longPressHandled) this.shortClick.emit(event);


### PR DESCRIPTION
* reason for bug was form change guard dialog on edited and unsaved documents
* make updating history stack depending on whether node is actually changed
* goToNode now asynchronous -> listen if succesful
* refactoring due to hiddenMenu being triggered by shortclick, when initialized
* introduced variable that controls hiddenMenu as default matMenuTrigger Event can not be prevented