### PR TITLE
Disable URL or Datensatzverweis field if the other is filled (#6473)

### DIFF
--- a/frontend/src/profiles/ingrid/doctypes/ingrid-shared.ts
+++ b/frontend/src/profiles/ingrid/doctypes/ingrid-shared.ts
@@ -1454,10 +1454,16 @@ export abstract class IngridShared extends BaseDoctype {
               "props.required": (field: FormlyFieldConfig) => {
                 return !field.form.value?.uuidRef;
               },
+              "props.disabled": (field: FormlyFieldConfig) => {
+                return !!field.form.value?.uuidRef;
+              },
+              "props.label": (field: FormlyFieldConfig) => {
+                return field.props.disabled ? "URL (nur bei leerem Datensatzverweis)" : "URL"
+              }
             },
             validation: {
               messages: {
-                required: "URL oder Datensatzverweis muss ausgefüllt sein",
+                required: "Entweder URL oder Datensatzverweis muss ausgefüllt sein",
               },
             },
           }),
@@ -1474,6 +1480,9 @@ export abstract class IngridShared extends BaseDoctype {
               hasInlineContextHelp: true,
               expressions: {
                 "props.required": 'field.form.value?.type?.key === "9990"', // Datendownload
+                "props.disabled": (field: FormlyFieldConfig) => {
+                  return !!field.form.value?.uuidRef;
+                },
               },
             },
           ),
@@ -1488,10 +1497,16 @@ export abstract class IngridShared extends BaseDoctype {
           "props.required": (field: FormlyFieldConfig) => {
             return !field.form.value?.url;
           },
+          "props.disabled": (field: FormlyFieldConfig) => {
+            return !!field.form.value?.url;
+          },
+          "props.label": (field: FormlyFieldConfig) => {
+            return field.props.disabled ? "Datensatzverweis (nur bei leerer URL)" : "Datensatzverweis"
+          }
         },
         validation: {
           messages: {
-            required: "URL oder Datensatzverweis muss ausgefüllt sein",
+            required: "Entweder URL oder Datensatzverweis muss ausgefüllt sein",
           },
         },
         asyncValidators: {

--- a/frontend/src/profiles/ingrid/doctypes/ingrid-shared.ts
+++ b/frontend/src/profiles/ingrid/doctypes/ingrid-shared.ts
@@ -1458,12 +1458,15 @@ export abstract class IngridShared extends BaseDoctype {
                 return !!field.form.value?.uuidRef;
               },
               "props.label": (field: FormlyFieldConfig) => {
-                return field.props.disabled ? "URL (nur bei leerem Datensatzverweis)" : "URL"
-              }
+                return field.props.disabled
+                  ? "URL (nur bei leerem Datensatzverweis)"
+                  : "URL";
+              },
             },
             validation: {
               messages: {
-                required: "Entweder URL oder Datensatzverweis muss ausgefüllt sein",
+                required:
+                  "Entweder URL oder Datensatzverweis muss ausgefüllt sein",
               },
             },
           }),
@@ -1501,8 +1504,10 @@ export abstract class IngridShared extends BaseDoctype {
             return !!field.form.value?.url;
           },
           "props.label": (field: FormlyFieldConfig) => {
-            return field.props.disabled ? "Datensatzverweis (nur bei leerer URL)" : "Datensatzverweis"
-          }
+            return field.props.disabled
+              ? "Datensatzverweis (nur bei leerer URL)"
+              : "Datensatzverweis";
+          },
         },
         validation: {
           messages: {


### PR DESCRIPTION
* Constrain input fields "URL" and "Datensatzverweis" in the "Verweise"-Modal, so that only one can have input at a time - the other is disabled dynamically