### PR TITLE
Feature/6388 improve codelist save

### DIFF
--- a/frontend/src/app/+catalog/codelists/catalog-codelists.component.html
+++ b/frontend/src/app/+catalog/codelists/catalog-codelists.component.html
@@ -72,6 +72,15 @@
                 >
                     <button
                         mat-flat-button
+                        color="accent"
+                        style="margin-right: auto"
+                        [hidden]="!showRefreshButton"
+                        (click)="refreshWindow()"
+                    >
+                        Aktualisieren
+                    </button>
+                    <button
+                        mat-flat-button
                         mat-stroked-button
                         (click)="resetCodelist()"
                     >

--- a/frontend/src/app/+catalog/codelists/catalog-codelists.component.html
+++ b/frontend/src/app/+catalog/codelists/catalog-codelists.component.html
@@ -72,15 +72,6 @@
                 >
                     <button
                         mat-flat-button
-                        color="accent"
-                        style="margin-right: auto"
-                        [hidden]="!showRefreshButton"
-                        (click)="refreshWindow()"
-                    >
-                        Aktualisieren
-                    </button>
-                    <button
-                        mat-flat-button
                         mat-stroked-button
                         (click)="resetCodelist()"
                     >

--- a/frontend/src/app/+catalog/codelists/catalog-codelists.component.ts
+++ b/frontend/src/app/+catalog/codelists/catalog-codelists.component.ts
@@ -80,7 +80,15 @@ export class CatalogCodelistsComponent implements OnInit {
     map((codelists) => codelists.sort((a, b) => a.name.localeCompare(b.name))),
     delay(0), // set initial value in next rendering cycle!
     tap((options) => (this.codelistsValue = options)),
-    tap((options) => this.setInitialValue()),
+    tap((options) => {
+      let codelistId = localStorage.getItem(this.codelistStorageKey);
+      localStorage.removeItem(this.codelistStorageKey);
+      let codelist = this.codelistsValue.find(
+        (option) => option.id === codelistId,
+      );
+      if (codelist) this.selectCodelist(codelist);
+      this.setInitialValue();
+    }),
   );
 
   selectedCodelist: Codelist;
@@ -92,8 +100,8 @@ export class CatalogCodelistsComponent implements OnInit {
   filteredOptions: Codelist[] = [];
 
   private codelistsValue: Codelist[];
+  private readonly codelistStorageKey = "codelist.selected.before.reload";
   showAllCodelists: boolean = true;
-  showRefreshButton: boolean = false;
 
   constructor(
     private codelistService: CodelistService,
@@ -230,16 +238,16 @@ export class CatalogCodelistsComponent implements OnInit {
       .updateCodelist(this.selectedCodelist)
       .pipe(
         tap(() => {
-          this._snackBar.open("Codeliste gespeichert");
-          this.showRefreshButton = true;
+          // store currently selected codelist
+          localStorage.setItem(
+            this.codelistStorageKey,
+            this.selectedCodelist.id,
+          );
+          window.location.reload();
         }),
+        tap(() => this._snackBar.open("Codeliste gespeichert")),
       )
       .subscribe();
-  }
-
-  refreshWindow() {
-    this.showRefreshButton = false;
-    window.location.reload();
   }
 
   private modifyCodelistEntry(oldId: string, result: CodelistEntry) {

--- a/frontend/src/app/+catalog/codelists/catalog-codelists.component.ts
+++ b/frontend/src/app/+catalog/codelists/catalog-codelists.component.ts
@@ -93,6 +93,7 @@ export class CatalogCodelistsComponent implements OnInit {
 
   private codelistsValue: Codelist[];
   showAllCodelists: boolean = true;
+  showRefreshButton: boolean = false;
 
   constructor(
     private codelistService: CodelistService,
@@ -227,8 +228,18 @@ export class CatalogCodelistsComponent implements OnInit {
   save() {
     this.codelistService
       .updateCodelist(this.selectedCodelist)
-      .pipe(tap(() => this._snackBar.open("Codeliste gespeichert")))
+      .pipe(
+        tap(() => {
+          this._snackBar.open("Codeliste gespeichert");
+          this.showRefreshButton = true;
+        }),
+      )
       .subscribe();
+  }
+
+  refreshWindow() {
+    this.showRefreshButton = false;
+    window.location.reload();
   }
 
   private modifyCodelistEntry(oldId: string, result: CodelistEntry) {

--- a/frontend/src/app/+catalog/codelists/catalog-codelists.component.ts
+++ b/frontend/src/app/+catalog/codelists/catalog-codelists.component.ts
@@ -81,15 +81,12 @@ export class CatalogCodelistsComponent implements OnInit {
     delay(0), // set initial value in next rendering cycle!
     tap((options) => (this.codelistsValue = options)),
     tap((options) => {
-      let codelistId = localStorage.getItem(this.codelistStorageKey);
-      localStorage.removeItem(this.codelistStorageKey);
-      let codelist = this.codelistsValue.find(
-        (option) => option.id === codelistId,
-      );
-      if (codelist) this.selectCodelist(codelist);
+      this.activateRememberedCodelist();
       this.setInitialValue();
     }),
   );
+
+  private readonly CODELIST_STORAGE_KEY = "codelist.selected.before.reload";
 
   selectedCodelist: Codelist;
   codelistSelect = new FormControl();
@@ -100,7 +97,6 @@ export class CatalogCodelistsComponent implements OnInit {
   filteredOptions: Codelist[] = [];
 
   private codelistsValue: Codelist[];
-  private readonly codelistStorageKey = "codelist.selected.before.reload";
   showAllCodelists: boolean = true;
 
   constructor(
@@ -240,9 +236,10 @@ export class CatalogCodelistsComponent implements OnInit {
         tap(() => {
           // store currently selected codelist
           localStorage.setItem(
-            this.codelistStorageKey,
+            this.CODELIST_STORAGE_KEY,
             this.selectedCodelist.id,
           );
+          // reload window to hard reset forms that rely on codelists
           window.location.reload();
         }),
         tap(() => this._snackBar.open("Codeliste gespeichert")),
@@ -292,6 +289,16 @@ export class CatalogCodelistsComponent implements OnInit {
       this.codelistSelect.setValue(initialValue);
       this.selectCodelist(initialValue);
     }
+  }
+
+  // retrieve temporarily saved "current" codelist, and remove from localStorage
+  private activateRememberedCodelist() {
+    let codelistId = localStorage.getItem(this.CODELIST_STORAGE_KEY);
+    localStorage.removeItem(this.CODELIST_STORAGE_KEY);
+    let codelist = this.codelistsValue.find(
+      (option) => option.id === codelistId,
+    );
+    if (codelist) this.selectCodelist(codelist);
   }
 
   resetAllCodelists() {


### PR DESCRIPTION
When a change is made to a codelist, this change is not immediately visible in the dataset view. A workaround is to refresh the application manually.

This PR introduces an automatic refresh after a codelist is saved, and returns the user to the changed codelist.