### PR TITLE
Improve responsiveness of UVP table when comparing a doc (#5578)

### DIFF
--- a/frontend/src/app/+form/dialogs/print-view/print-view-dialog.component.html
+++ b/frontend/src/app/+form/dialogs/print-view/print-view-dialog.component.html
@@ -20,12 +20,14 @@
 
     <div content id="print-content" class="preview-dialog">
         @if (!compareView) {
-            <formly-form
-                [form]="form"
-                [fields]="data.fields"
-                [model]="data.model"
-                [options]="options"
-            ></formly-form>
+            <div class="preview-print">
+                <formly-form
+                    [form]="form"
+                    [fields]="data.fields"
+                    [model]="data.model"
+                    [options]="options"
+                ></formly-form>
+            </div>
         }
         @if (compareView) {
             <as-split>

--- a/frontend/src/app/+form/dialogs/print-view/print-view-dialog.component.ts
+++ b/frontend/src/app/+form/dialogs/print-view/print-view-dialog.component.ts
@@ -44,6 +44,10 @@ import { DialogTemplateModule } from "../../../shared/dialog-template/dialog-tem
         font-size: 14px;
         border: none;
       }
+      .preview-print {
+        max-width: min(950px, 90vw);
+        margin: auto !important;
+      }
     `,
   ],
   providers: [MixedDragDropConfig],

--- a/frontend/src/app/+form/dialogs/print-view/print-view.plugin.ts
+++ b/frontend/src/app/+form/dialogs/print-view/print-view.plugin.ts
@@ -124,6 +124,7 @@ export class PrintViewPlugin extends Plugin {
       }
       this.dialog.open(PrintViewDialogComponent, {
         width: "80%",
+        maxWidth: "90vw",
         data: {
           fields: fields,
           fieldsPublished: fieldsPublished,

--- a/frontend/src/app/formly/types/print/print-type.component.scss
+++ b/frontend/src/app/formly/types/print/print-type.component.scss
@@ -1,3 +1,4 @@
 :host {
   padding-top: 10px;
+  min-height: 30px;
 }

--- a/frontend/src/app/formly/types/table/table-type.component.scss
+++ b/frontend/src/app/formly/types/table/table-type.component.scss
@@ -66,6 +66,7 @@ ige-form-label {
     padding-top: 6px;
     padding-bottom: 6px;
     word-break: break-all;
+    align-items: baseline;
   }
 
   ::ng-deep .disabled mat-cell {

--- a/frontend/src/profiles/ingrid/doctypes/ingrid-shared.ts
+++ b/frontend/src/profiles/ingrid/doctypes/ingrid-shared.ts
@@ -1125,7 +1125,7 @@ export abstract class IngridShared extends BaseDoctype {
                   key: "pass",
                   type: "ige-select",
                   label: "Grad",
-                  width: "100px",
+                  width: "130px",
                   props: {
                     required: true,
                     label: "Grad",

--- a/frontend/src/profiles/uvp/doctypes/uvp-shared.ts
+++ b/frontend/src/profiles/uvp/doctypes/uvp-shared.ts
@@ -54,7 +54,7 @@ export class UvpShared extends BaseDoctype {
       key: "title",
       type: "input",
       label: "Titel",
-      class: "longtext-no-wrap",
+      width: "300px",
       props: {
         label: "Titel",
         appearance: "outline",
@@ -65,7 +65,6 @@ export class UvpShared extends BaseDoctype {
       key: "downloadURL",
       type: "upload",
       label: "Link",
-      width: "150px",
       wrappers: ["form-field", "inline-help"],
       props: {
         label: "Link",

--- a/frontend/src/profiles/uvp/doctypes/uvp-shared.ts
+++ b/frontend/src/profiles/uvp/doctypes/uvp-shared.ts
@@ -54,7 +54,7 @@ export class UvpShared extends BaseDoctype {
       key: "title",
       type: "input",
       label: "Titel",
-      width: "300px",
+      class: "longtext-no-wrap",
       props: {
         label: "Titel",
         appearance: "outline",
@@ -65,6 +65,7 @@ export class UvpShared extends BaseDoctype {
       key: "downloadURL",
       type: "upload",
       label: "Link",
+      width: "150px",
       wrappers: ["form-field", "inline-help"],
       props: {
         label: "Link",
@@ -75,10 +76,10 @@ export class UvpShared extends BaseDoctype {
         },
         formatter: (link: any) => {
           if (link.asLink) {
-            return `<a  href="${link.uri}" target="_blank" class="no-text-transform icon-in-table">
+            return `<a  href="${link.uri}" target="_blank" class="no-text-transform icon-in-table longtext-no-wrap">
                          <img  width="20"  height="20" src="assets/icons/external_link.svg"  alt="link"> ${link.uri}  </a> `;
           } else {
-            return `<span class="clickable-text icon-in-table">  <img  width="20"  height="20" src="assets/icons/download.svg"  alt="link"> ${link.uri}</span>`;
+            return `<span class="clickable-text icon-in-table longtext-no-wrap">  <img  width="20"  height="20" src="assets/icons/download.svg"  alt="link"> ${link.uri}</span>`;
           }
         },
       },
@@ -103,7 +104,7 @@ export class UvpShared extends BaseDoctype {
       key: "validUntil",
       type: "datepicker",
       label: "Gültig bis",
-      width: "100px",
+      width: "120px",
       props: {
         label: "Gültig bis",
         appearance: "outline",

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1376,3 +1376,8 @@ table.big-font {
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
 }
+
+.longtext-no-wrap {
+  white-space: nowrap; /* Prevent text from wrapping */
+  overflow: hidden; /* Hide any overflow text */
+}


### PR DESCRIPTION
- No line wrap for table content
- Bigger width for date field
- Set a min-height for input fields for better comparability when field is empty