### PR TITLE
OGC API extention to move records to within folder structure

### DIFF
--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_distributions/api/OgcDistributionsApiController.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_distributions/api/OgcDistributionsApiController.kt
@@ -79,7 +79,7 @@ class OgcDistributionsApiController(
         principal: Authentication,
         @Parameter(description = "## Collection ID \n **OGC Parameter** \n\n The identifier for a specific record collection (i.e. catalogue identifier).", required = true) @PathVariable("collectionId") collectionId: String,
         @Parameter(description = "## Record ID \n **OGC Parameter** \n\n The identifier for a specific record (i.e. record identifier).", required = true) @PathVariable("recordId") recordId: String,
-        @Parameter(description = "## distribution ID \n\n The Identifier of the distribution.") @RequestParam(value = "uri", required = true) distributionId: String,
+        @Parameter(description = "## Filename as distribution ID \n\n The filename is the identifier of the distribution.") @RequestParam(value = "filename", required = true) distributionId: String,
     ): ResponseEntity<String> {
         val userID = principal.name
         ogcDistributionsService.handleDeleteDistribution(principal, userID, collectionId, recordId, distributionId)

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/api/OgcApiRecordsController.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/api/OgcApiRecordsController.kt
@@ -501,4 +501,25 @@ class OgcApiRecordsController(
 
         return ResponseEntity.ok().headers(responseHeaders).body(records)
     }
+
+    @PostMapping(value = ["/collections/{collectionId}/items/actions/move"], consumes = [MediaType.APPLICATION_JSON_VALUE], produces = [MediaType.APPLICATION_JSON_VALUE, MediaType.TEXT_HTML_VALUE])
+    @Operation(tags = ["OGC/Records/Actions"], summary = "Relocate/move record(s) to folder ID.", hidden = false)
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Successful operation."),
+            ApiResponse(responseCode = "400", description = "Invalid input"),
+            ApiResponse(responseCode = "404", description = "Not found"),
+        ],
+    )
+    fun actionMoveRecords(
+        @Parameter(hidden = true) @RequestParam allRequestParams: Map<String, String>,
+        @RequestHeader allHeaders: Map<String, String>,
+        principal: Authentication,
+        @Parameter(description = "## Collection ID \n **OGC Parameter** \n\n The identifier for a specific record collection (i.e. catalogue identifier).", required = true) @PathVariable("collectionId") collectionId: String,
+        @Parameter(description = "The dataset to be stored.", required = true) @RequestBody data: String,
+    ): ResponseEntity<JsonNode> {
+        apiValidationService.validateCollection(collectionId)
+        ogcRecordService.moveRecords(collectionId, data)
+        return ResponseEntity.ok().build()
+    }
 }


### PR DESCRIPTION
- New endpoint '/collections/{collectionId}/items/actions/move'
- Move records to folder or move it to root
- Prevent to move datasets to an address folder and vice versa
- Check if requested target folder is a of type 'FOLDER'

This pull request also includes a fix for the ogc distributions endpoint. To avoid missconceptions the request parameter "uri" was renamed to "filename" since it does not represent a uri.