### PR TITLE
feature/fix-iso-import-fileReferenceFormat

### DIFF
--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/ApplicationMapper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/ApplicationMapper.kt
@@ -23,9 +23,10 @@ import de.ingrid.igeserver.ServerException
 import de.ingrid.igeserver.model.KeyValue
 import de.ingrid.igeserver.profiles.ingrid.exporter.model.ServiceUrl
 import de.ingrid.igeserver.profiles.ingrid.iso639LanguageMapping
+import de.ingrid.mdek.upload.Config
 import org.apache.logging.log4j.kotlin.logger
 
-open class ApplicationMapper(isoData: IsoImportData) : GeneralMapper(isoData) {
+open class ApplicationMapper(isoData: IsoImportData, config: Config) : GeneralMapper(isoData, config) {
 
     val log = logger()
     val identificationInfo = metadata.identificationInfo[0].dataIdentificationInfo

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeneralMapper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeneralMapper.kt
@@ -345,7 +345,7 @@ open class GeneralMapper(val isoData: IsoImportData, val config: Config) {
 
     fun getGraphicOverviews(): List<PreviewGraphic> = metadata.identificationInfo[0].identificationInfo?.graphicOverview
         ?.map {
-            val isInternalStorage: Boolean = it.mdBrowseGraphic?.fileName?.value?.contains(config.uploadExternalUrl) ?: false
+            val isInternalStorage: Boolean = it.mdBrowseGraphic?.fileName?.value?.contains(config.uploadExternalUrl ?: "/documents/") ?: false
             val fileName = if (isInternalStorage) {
                 it.mdBrowseGraphic?.fileName?.value?.substringAfterLast('/')
             } else {

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeneralMapper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeneralMapper.kt
@@ -643,9 +643,9 @@ open class GeneralMapper(val isoData: IsoImportData) {
                 ?.filter { transferOption.mdDigitalTransferOptions.unitsOfDistribution?.value == "MB" }
                 ?.mapNotNull { it.ciOnlineResource }
                 ?.map { resource ->
-                    val codeListValue = resource.function?.code?.codeListValue
+                    val fileFormatCode = resource.applicationProfile?.value
                     val typeId =
-                        if (codeListValue == null) null else codeListService.getCodeListEntryId("2000", codeListValue, "iso")
+                        if (fileFormatCode == null) null else codeListService.getCodeListEntryId("1320", fileFormatCode, "de")
                     val keyValue = if (typeId == null) KeyValue("9999") else KeyValue(typeId)
                     val fileName = resource.linkage.url?.substringAfterLast('/') ?: ""
                     val sizeInBytes = transferOption.mdDigitalTransferOptions.transferSize?.value?.times(1_000_000)

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeneralMapper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeneralMapper.kt
@@ -35,6 +35,7 @@ import de.ingrid.igeserver.profiles.ingrid.utils.FieldToCodelist
 import de.ingrid.igeserver.services.CodelistHandler
 import de.ingrid.igeserver.services.DocumentService
 import de.ingrid.igeserver.utils.convertGml32ToWkt
+import de.ingrid.mdek.upload.Config
 import de.ingrid.utils.udk.TM_PeriodDurationToTimeAlle
 import de.ingrid.utils.udk.TM_PeriodDurationToTimeInterval
 import de.ingrid.utils.udk.UtilsCountryCodelist
@@ -45,7 +46,7 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.*
 
-open class GeneralMapper(val isoData: IsoImportData) {
+open class GeneralMapper(val isoData: IsoImportData, val config: Config) {
 
     private val log = logger()
 
@@ -344,7 +345,7 @@ open class GeneralMapper(val isoData: IsoImportData) {
 
     fun getGraphicOverviews(): List<PreviewGraphic> = metadata.identificationInfo[0].identificationInfo?.graphicOverview
         ?.map {
-            val isInternalStorage: Boolean = it.mdBrowseGraphic?.fileName?.value?.contains("/documents/") ?: false
+            val isInternalStorage: Boolean = it.mdBrowseGraphic?.fileName?.value?.contains(config.uploadExternalUrl) ?: false
             val fileName = if (isInternalStorage) {
                 it.mdBrowseGraphic?.fileName?.value?.substringAfterLast('/')
             } else {

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeodatasetMapper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeodatasetMapper.kt
@@ -34,9 +34,10 @@ import de.ingrid.igeserver.model.BoolFilter
 import de.ingrid.igeserver.model.KeyValue
 import de.ingrid.igeserver.model.ResearchQuery
 import de.ingrid.igeserver.profiles.ingrid.iso639LanguageMapping
+import de.ingrid.mdek.upload.Config
 import org.apache.logging.log4j.kotlin.logger
 
-open class GeodatasetMapper(isoData: IsoImportData) : GeneralMapper(isoData) {
+open class GeodatasetMapper(isoData: IsoImportData, config: Config) : GeneralMapper(isoData, config) {
 
     val log = logger()
     val identificationInfo = metadata.identificationInfo[0].dataIdentificationInfo

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeoserviceMapper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeoserviceMapper.kt
@@ -21,8 +21,9 @@ package de.ingrid.igeserver.profiles.ingrid.importer.iso19139
 
 import de.ingrid.igeserver.exports.iso.OperatesOn
 import de.ingrid.igeserver.model.KeyValue
+import de.ingrid.mdek.upload.Config
 
-open class GeoserviceMapper(isoData: IsoImportData) : GeneralMapper(isoData) {
+open class GeoserviceMapper(isoData: IsoImportData, config: Config) : GeneralMapper(isoData, config) {
 
     val info = metadata.identificationInfo[0].identificationInfo
 

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/ISOImport.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/ISOImport.kt
@@ -35,6 +35,7 @@ import de.ingrid.igeserver.services.CatalogService
 import de.ingrid.igeserver.services.CodelistHandler
 import de.ingrid.igeserver.services.DocumentService
 import de.ingrid.igeserver.services.ResearchService
+import de.ingrid.mdek.upload.Config
 import gg.jte.ContentType
 import gg.jte.TemplateEngine
 import gg.jte.TemplateOutput
@@ -59,7 +60,7 @@ data class IsoConverterOutput(
 )
 
 @Service
-class ISOImport(val codelistService: CodelistHandler, @Lazy val catalogService: CatalogService, @Lazy val documentService: DocumentService, @Lazy val researchService: ResearchService) : IgeImporter {
+class ISOImport(val codelistService: CodelistHandler, @Lazy val catalogService: CatalogService, @Lazy val documentService: DocumentService, @Lazy val researchService: ResearchService, val config: Config) : IgeImporter {
     private val log = logger()
 
     val templateEngine: TemplateEngine = TemplateEngine.createPrecompiled(ContentType.Plain)
@@ -103,22 +104,22 @@ class ISOImport(val codelistService: CodelistHandler, @Lazy val catalogService: 
 
         when (val hierarchyLevel = isoData.data.hierarchyLevel?.get(0)?.scopeCode?.codeListValue) {
             "service" -> {
-                model = GeoserviceMapper(isoData)
+                model = GeoserviceMapper(isoData, config)
                 templateEngine.render("imports/ingrid/geoservice.jte", mapOf("model" to model), output)
             }
 
             "dataset" -> {
-                model = GeodatasetMapper(isoData)
+                model = GeodatasetMapper(isoData, config)
                 templateEngine.render("imports/ingrid/geodataset.jte", mapOf("model" to model), output)
             }
 
             "series" -> {
-                model = GeodatasetMapper(isoData)
+                model = GeodatasetMapper(isoData, config)
                 templateEngine.render("imports/ingrid/geodataset.jte", mapOf("model" to model), output)
             }
 
             "application" -> {
-                model = ApplicationMapper(isoData)
+                model = ApplicationMapper(isoData, config)
                 templateEngine.render("imports/ingrid/application.jte", mapOf("model" to model), output)
             }
 

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_hmdk/importer/GeodatasetMapperHMDK.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_hmdk/importer/GeodatasetMapperHMDK.kt
@@ -22,8 +22,9 @@ package de.ingrid.igeserver.profiles.ingrid_hmdk.importer
 import de.ingrid.igeserver.model.KeyValue
 import de.ingrid.igeserver.profiles.ingrid.importer.iso19139.GeodatasetMapper
 import de.ingrid.igeserver.profiles.ingrid.importer.iso19139.IsoImportData
+import de.ingrid.mdek.upload.Config
 
-class GeodatasetMapperHMDK(isoData: IsoImportData) : GeodatasetMapper(isoData) {
+class GeodatasetMapperHMDK(isoData: IsoImportData, config: Config) : GeodatasetMapper(isoData, config) {
 
     val publicationHmbTG = containsKeyword("hmbtg")
 

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_hmdk/importer/GeoserviceMapperHMDK.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_hmdk/importer/GeoserviceMapperHMDK.kt
@@ -22,8 +22,9 @@ package de.ingrid.igeserver.profiles.ingrid_hmdk.importer
 import de.ingrid.igeserver.model.KeyValue
 import de.ingrid.igeserver.profiles.ingrid.importer.iso19139.GeoserviceMapper
 import de.ingrid.igeserver.profiles.ingrid.importer.iso19139.IsoImportData
+import de.ingrid.mdek.upload.Config
 
-class GeoserviceMapperHMDK(isoData: IsoImportData) : GeoserviceMapper(isoData) {
+class GeoserviceMapperHMDK(isoData: IsoImportData, config: Config) : GeoserviceMapper(isoData, config) {
 
     val publicationHmbTG = containsKeyword("hmbtg")
 

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_hmdk/importer/ISOImportHMDK.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_hmdk/importer/ISOImportHMDK.kt
@@ -26,11 +26,12 @@ import de.ingrid.igeserver.profiles.ingrid.importer.iso19139.IsoImportData
 import de.ingrid.igeserver.services.CodelistHandler
 import de.ingrid.igeserver.services.DocumentService
 import de.ingrid.igeserver.services.ResearchService
+import de.ingrid.mdek.upload.Config
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 
 @Service
-class ISOImportHMDK(val codelistHandler: CodelistHandler, @Lazy val documentService: DocumentService, @Lazy val researchService: ResearchService) :
+class ISOImportHMDK(val codelistHandler: CodelistHandler, @Lazy val documentService: DocumentService, @Lazy val researchService: ResearchService, val config: Config) :
     ISOImportProfile {
     override fun handle(
         catalogId: String,
@@ -43,14 +44,14 @@ class ISOImportHMDK(val codelistHandler: CodelistHandler, @Lazy val documentServ
             "dataset", "series" -> {
                 ImportProfileData(
                     "imports/ingrid-hmdk/geodataset.jte",
-                    GeodatasetMapperHMDK(isoData),
+                    GeodatasetMapperHMDK(isoData, config),
                 )
             }
 
             "service" -> {
                 ImportProfileData(
                     "imports/ingrid-hmdk/geoservice.jte",
-                    GeoserviceMapperHMDK(isoData),
+                    GeoserviceMapperHMDK(isoData, config),
                 )
             }
 

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_krzn/importer/ISOImportKRZN.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_krzn/importer/ISOImportKRZN.kt
@@ -27,11 +27,12 @@ import de.ingrid.igeserver.profiles.ingrid.importer.iso19139.IsoImportData
 import de.ingrid.igeserver.services.CodelistHandler
 import de.ingrid.igeserver.services.DocumentService
 import de.ingrid.igeserver.services.ResearchService
+import de.ingrid.mdek.upload.Config
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 
 @Service
-class ISOImportKRZN(val codelistHandler: CodelistHandler, @Lazy val documentService: DocumentService, @Lazy val researchService: ResearchService) :
+class ISOImportKRZN(val codelistHandler: CodelistHandler, @Lazy val documentService: DocumentService, @Lazy val researchService: ResearchService, val config: Config) :
     ISOImportProfile {
     override fun handle(catalogId: String, data: Metadata, addressMaps: MutableMap<String, String>): ImportProfileData? {
         val isoData = IsoImportData(data, codelistHandler, catalogId, documentService, addressMaps, researchService)
@@ -40,7 +41,7 @@ class ISOImportKRZN(val codelistHandler: CodelistHandler, @Lazy val documentServ
             "dataset" -> {
                 ImportProfileData(
                     "imports/ingrid-krzn/geodataset.jte",
-                    GeodatasetMapper(isoData),
+                    GeodatasetMapper(isoData, config),
                 )
             }
 

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/importer/ApplicationMapperLfUBayern.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/importer/ApplicationMapperLfUBayern.kt
@@ -21,8 +21,9 @@ package de.ingrid.igeserver.profiles.ingrid_lfubayern.importer
 
 import de.ingrid.igeserver.profiles.ingrid.importer.iso19139.ApplicationMapper
 import de.ingrid.igeserver.profiles.ingrid.importer.iso19139.IsoImportData
+import de.ingrid.mdek.upload.Config
 
-class ApplicationMapperLfUBayern(isoData: IsoImportData) : ApplicationMapper(isoData) {
+class ApplicationMapperLfUBayern(isoData: IsoImportData, config: Config) : ApplicationMapper(isoData, config) {
 
     init {
         fieldToCodelist.referenceFileFormat = "20002"

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/importer/GeodatasetMapperLfUBayern.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/importer/GeodatasetMapperLfUBayern.kt
@@ -22,8 +22,9 @@ package de.ingrid.igeserver.profiles.ingrid_lfubayern.importer
 import de.ingrid.igeserver.model.KeyValue
 import de.ingrid.igeserver.profiles.ingrid.importer.iso19139.GeodatasetMapper
 import de.ingrid.igeserver.profiles.ingrid.importer.iso19139.IsoImportData
+import de.ingrid.mdek.upload.Config
 
-class GeodatasetMapperLfUBayern(isoData: IsoImportData) : GeodatasetMapper(isoData) {
+class GeodatasetMapperLfUBayern(isoData: IsoImportData, config: Config) : GeodatasetMapper(isoData, config) {
 
     init {
         fieldToCodelist.referenceFileFormat = "20002"

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/importer/GeoserviceMapperLfUBayern.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/importer/GeoserviceMapperLfUBayern.kt
@@ -22,8 +22,9 @@ package de.ingrid.igeserver.profiles.ingrid_lfubayern.importer
 import de.ingrid.igeserver.model.KeyValue
 import de.ingrid.igeserver.profiles.ingrid.importer.iso19139.GeoserviceMapper
 import de.ingrid.igeserver.profiles.ingrid.importer.iso19139.IsoImportData
+import de.ingrid.mdek.upload.Config
 
-class GeoserviceMapperLfUBayern(isoData: IsoImportData) : GeoserviceMapper(isoData) {
+class GeoserviceMapperLfUBayern(isoData: IsoImportData, config: Config) : GeoserviceMapper(isoData, config) {
 
     init {
         fieldToCodelist.referenceFileFormat = "20002"

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/importer/ISOImportLfUBayern.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/importer/ISOImportLfUBayern.kt
@@ -26,11 +26,12 @@ import de.ingrid.igeserver.profiles.ingrid.importer.iso19139.IsoImportData
 import de.ingrid.igeserver.services.CodelistHandler
 import de.ingrid.igeserver.services.DocumentService
 import de.ingrid.igeserver.services.ResearchService
+import de.ingrid.mdek.upload.Config
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 
 @Service
-class ISOImportLfUBayern(val codelistHandler: CodelistHandler, @Lazy val documentService: DocumentService, @Lazy val researchService: ResearchService) :
+class ISOImportLfUBayern(val codelistHandler: CodelistHandler, @Lazy val documentService: DocumentService, @Lazy val researchService: ResearchService, val config: Config) :
     ISOImportProfile {
     override fun handle(catalogId: String, data: Metadata, addressMaps: MutableMap<String, String>): ImportProfileData? {
         val isoData = IsoImportData(data, codelistHandler, catalogId, documentService, addressMaps, researchService)
@@ -39,28 +40,28 @@ class ISOImportLfUBayern(val codelistHandler: CodelistHandler, @Lazy val documen
             "service" -> {
                 ImportProfileData(
                     "imports/ingrid-lfubayern/geoservice.jte",
-                    GeoserviceMapperLfUBayern(isoData),
+                    GeoserviceMapperLfUBayern(isoData, config),
                 )
             }
 
             "dataset" -> {
                 ImportProfileData(
                     "imports/ingrid-lfubayern/geodataset.jte",
-                    GeodatasetMapperLfUBayern(isoData),
+                    GeodatasetMapperLfUBayern(isoData, config),
                 )
             }
 
             "series" -> {
                 ImportProfileData(
                     "imports/ingrid-lfubayern/geodataset.jte",
-                    GeodatasetMapperLfUBayern(isoData),
+                    GeodatasetMapperLfUBayern(isoData, config),
                 )
             }
 
             "application" -> {
                 ImportProfileData(
                     "imports/ingrid-lfubayern/application.jte",
-                    ApplicationMapperLfUBayern(isoData),
+                    ApplicationMapperLfUBayern(isoData, config),
                 )
             }
 

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lubw/importer/GeodatasetMapperLUBW.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lubw/importer/GeodatasetMapperLUBW.kt
@@ -22,8 +22,9 @@ package de.ingrid.igeserver.profiles.ingrid_lubw.importer
 import de.ingrid.igeserver.exports.iso.MDDataIdentification
 import de.ingrid.igeserver.profiles.ingrid.importer.iso19139.GeodatasetMapper
 import de.ingrid.igeserver.profiles.ingrid.importer.iso19139.IsoImportData
+import de.ingrid.mdek.upload.Config
 
-class GeodatasetMapperLUBW(isoData: IsoImportData) : GeodatasetMapper(isoData) {
+class GeodatasetMapperLUBW(isoData: IsoImportData, config: Config) : GeodatasetMapper(isoData, config) {
 
     override fun getKeywords(): List<String> = super.getKeywords().filterNot { it.startsWith("oac: ") }
 

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lubw/importer/ISOImportLUBW.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lubw/importer/ISOImportLUBW.kt
@@ -27,11 +27,12 @@ import de.ingrid.igeserver.profiles.ingrid.importer.iso19139.IsoImportData
 import de.ingrid.igeserver.services.CodelistHandler
 import de.ingrid.igeserver.services.DocumentService
 import de.ingrid.igeserver.services.ResearchService
+import de.ingrid.mdek.upload.Config
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 
 @Service
-class ISOImportLUBW(val codelistHandler: CodelistHandler, @Lazy val documentService: DocumentService, @Lazy val researchService: ResearchService) :
+class ISOImportLUBW(val codelistHandler: CodelistHandler, @Lazy val documentService: DocumentService, @Lazy val researchService: ResearchService, val config: Config) :
     ISOImportProfile {
     override fun handle(catalogId: String, data: Metadata, addressMaps: MutableMap<String, String>): ImportProfileData? {
         val isoData = IsoImportData(data, codelistHandler, catalogId, documentService, addressMaps, researchService)
@@ -40,14 +41,14 @@ class ISOImportLUBW(val codelistHandler: CodelistHandler, @Lazy val documentServ
             "dataset", "series" -> {
                 ImportProfileData(
                     "imports/ingrid-lubw/geodataset.jte",
-                    GeodatasetMapperLUBW(isoData),
+                    GeodatasetMapperLUBW(isoData, config),
                 )
             }
 
             "service" -> {
                 ImportProfileData(
                     "imports/ingrid/geoservice.jte",
-                    GeoserviceMapper(isoData),
+                    GeoserviceMapper(isoData, config),
                 )
             }
 

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_up_sh/importer/ISOImportUPSH.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_up_sh/importer/ISOImportUPSH.kt
@@ -27,11 +27,12 @@ import de.ingrid.igeserver.profiles.ingrid.importer.iso19139.IsoImportData
 import de.ingrid.igeserver.services.CodelistHandler
 import de.ingrid.igeserver.services.DocumentService
 import de.ingrid.igeserver.services.ResearchService
+import de.ingrid.mdek.upload.Config
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 
 @Service
-class ISOImportUPSH(val codelistHandler: CodelistHandler, @Lazy val documentService: DocumentService, @Lazy val researchService: ResearchService) :
+class ISOImportUPSH(val codelistHandler: CodelistHandler, @Lazy val documentService: DocumentService, @Lazy val researchService: ResearchService, val config: Config) :
     ISOImportProfile {
     override fun handle(catalogId: String, data: Metadata, addressMaps: MutableMap<String, String>): ImportProfileData? {
         val isoData = IsoImportData(data, codelistHandler, catalogId, documentService, addressMaps, researchService)
@@ -40,7 +41,7 @@ class ISOImportUPSH(val codelistHandler: CodelistHandler, @Lazy val documentServ
             "dataset" -> {
                 ImportProfileData(
                     "imports/ingrid-up-sh/geodataset.jte",
-                    GeodatasetMapper(isoData),
+                    GeodatasetMapper(isoData, config),
                 )
             }
 

--- a/server/src/test/kotlin/de/ingrid/igeserver/imports/ingrid_lfubayern/IsoImporterLfuBayernTest.kt
+++ b/server/src/test/kotlin/de/ingrid/igeserver/imports/ingrid_lfubayern/IsoImporterLfuBayernTest.kt
@@ -28,6 +28,7 @@ import de.ingrid.igeserver.services.CatalogService
 import de.ingrid.igeserver.services.CodelistHandler
 import de.ingrid.igeserver.services.DocumentService
 import de.ingrid.igeserver.services.ResearchService
+import de.ingrid.mdek.upload.Config
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.core.spec.style.AnnotationSpec
 import io.mockk.every
@@ -41,6 +42,7 @@ class IsoImporterLfuBayernTest : AnnotationSpec() {
     private val documentService = mockk<DocumentService>()
     private val documentRepository = mockk<DocumentRepository>()
     private val researchService = mockk<ResearchService>()
+    private val config = mockk<Config>()
 
     @BeforeAll
     fun beforeAll() {
@@ -58,8 +60,8 @@ class IsoImporterLfuBayernTest : AnnotationSpec() {
 
     @Test
     fun importGeoservice() {
-        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService)
-        isoImporter.profileMapper["ingrid-lfubayern"] = ISOImportLfUBayern(codelistService, documentService, researchService)
+        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService, config)
+        isoImporter.profileMapper["ingrid-lfubayern"] = ISOImportLfUBayern(codelistService, documentService, researchService, config)
         val result = isoImporter.run("test", getFile("ingrid/import/iso_geodataset_full_lfuBayern.xml"), mutableMapOf())
         println(result.toString())
 

--- a/server/src/test/kotlin/de/ingrid/igeserver/imports/iso/IsoImporterTest.kt
+++ b/server/src/test/kotlin/de/ingrid/igeserver/imports/iso/IsoImporterTest.kt
@@ -40,6 +40,7 @@ import de.ingrid.igeserver.services.DocumentService
 import de.ingrid.igeserver.services.ResearchService
 import de.ingrid.igeserver.services.Result
 import de.ingrid.igeserver.utils.getString
+import de.ingrid.mdek.upload.Config
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
@@ -56,6 +57,7 @@ class IsoImporterTest : AnnotationSpec() {
     private val documentService = mockk<DocumentService>()
     private val documentRepository = mockk<DocumentRepository>()
     private val researchService = mockk<ResearchService>()
+    private val config = mockk<Config>()
 
     @BeforeAll
     fun beforeAll() {
@@ -96,7 +98,7 @@ class IsoImporterTest : AnnotationSpec() {
 
     @Test
     fun importGeoservice() {
-        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService)
+        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService, config)
         val result = isoImporter.run("test", getFile("ingrid/import/iso_geoservice_full.xml"), mutableMapOf())
 
         changeUuidOfOrganisationTo(result, "Objektbesitzer Institut", "D")
@@ -110,7 +112,7 @@ class IsoImporterTest : AnnotationSpec() {
 
     @Test
     fun importGeodataset() {
-        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService)
+        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService, config)
         val result = isoImporter.run("test", getFile("ingrid/import/iso_geodataset_full.xml"), mutableMapOf())
 
         changeUuidOfOrganisationTo(result, "Some Organisation", "some_organisation")
@@ -122,7 +124,7 @@ class IsoImporterTest : AnnotationSpec() {
 
     @Test
     fun addressHierarchy1() {
-        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService)
+        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService, config)
 
         val data = addPointOfContact(
             minimalMetadata,
@@ -146,7 +148,7 @@ class IsoImporterTest : AnnotationSpec() {
 
     @Test
     fun addressHierarchy2() {
-        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService)
+        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService, config)
 
         val data = addPointOfContact(
             minimalMetadata,
@@ -173,7 +175,7 @@ class IsoImporterTest : AnnotationSpec() {
 
     @Test
     fun addressHierarchy3() {
-        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService)
+        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService, config)
 
         val data = addPointOfContact(
             minimalMetadata,
@@ -206,7 +208,7 @@ class IsoImporterTest : AnnotationSpec() {
 
     @Test
     fun addressHierarchy4() {
-        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService)
+        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService, config)
 
         val data = addPointOfContact(
             minimalMetadata,
@@ -239,7 +241,7 @@ class IsoImporterTest : AnnotationSpec() {
 
     @Test
     fun addressHierarchy5() {
-        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService)
+        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService, config)
 
         val data = addPointOfContact(
             minimalMetadata,
@@ -265,7 +267,7 @@ class IsoImporterTest : AnnotationSpec() {
 
     @Test
     fun addressHierarchy6() {
-        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService)
+        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService, config)
 
         val data = addPointOfContact(
             minimalMetadata,
@@ -292,7 +294,7 @@ class IsoImporterTest : AnnotationSpec() {
 
     @Test
     fun importAddressAsPointOfContactMDAndPointOfContact() {
-        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService)
+        val isoImporter = ISOImport(codelistService, catalogService, documentService, researchService, config)
 
         val pointOfContact = """
             <gmd:pointOfContact>

--- a/server/src/test/resources/ingrid/import/iso_geodataset_full-expected.json
+++ b/server/src/test/resources/ingrid/import/iso_geodataset_full-expected.json
@@ -305,7 +305,7 @@
         },
         "title": "Platzhalter Titel",
         "format": {
-          "key": "9990"
+          "key": "5"
         },
         "description": "Platzhalter Beschreibung"
       }

--- a/server/src/test/resources/ingrid/import/iso_geodataset_full.xml
+++ b/server/src/test/resources/ingrid/import/iso_geodataset_full.xml
@@ -834,7 +834,7 @@
                                 <gmd:URL>/documents/catalogId/4915275a-733a-47cd-b1a6-1a3f1e976948/placeholder.pdf</gmd:URL>
                             </gmd:linkage>
                             <gmd:applicationProfile>
-                                <gco:CharacterString/>
+                                <gco:CharacterString>Bitmap</gco:CharacterString>
                             </gmd:applicationProfile>
                             <gmd:name>
                                 <gco:CharacterString>Platzhalter Titel</gco:CharacterString>


### PR DESCRIPTION
This branch contains 2 fixes
- Correct import of fileReference with its format
- Add application config to importer and mapper to identify internal file storage of preview graphic
- Fix tests