### PR TITLE
Feature/6963 index references

### DIFF
--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/extensions/InGridPublishExport.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/extensions/InGridPublishExport.kt
@@ -56,30 +56,33 @@ class InGridPublishExport(
             if (isDocument) {
                 indexDoc(context, docId, DocumentCategory.DATA)
                 val dataType = payload.wrapper.type
-                GlobalScope.launch {
-                    if (dataType == "InGridGeoDataset") {
-                        indexReferencedDocs(
-                            context,
-                            "Index documents referenced by dataset $docId to Elasticsearch",
-                            """
-                            d.uuid IN (
-                                SELECT jsonb_array_elements(data->'references')->>'uuidRef'
-                                FROM document
-                                WHERE uuid = '$docId')
-                            """.trimIndent()
-                        )
-                    } else if (dataType == "InGridGeoService") {
-                        indexReferencedDocs(
-                            context,
-                            "Index documents coupled to service $docId to Elasticsearch",
-                            """
-                            d.uuid IN (
-                                SELECT jsonb_array_elements(data->'service'->'coupledResources')->>'uuid'
-                                FROM document
-                                WHERE uuid = '$docId')
-                            """.trimIndent()
-                        )
-                    }
+                val version = payload.document.version
+                // we cannot use GlobalScope here, because we need data from the previous version
+                // this can only be reliably determined if we're in the same transaction
+                if (dataType == "InGridGeoDataset") {
+                    indexReferencedDocs(
+                        context,
+                        "Index documents (previously or currently) referenced by dataset $docId to Elasticsearch",
+                        """
+                        d.uuid IN (
+                            SELECT jsonb_array_elements(data->'references')->>'uuidRef'
+                            FROM document
+                            WHERE uuid = '$docId'
+                                AND version=$version)
+                        """.trimIndent()
+                    )
+                } else if (dataType == "InGridGeoService") {
+                    indexReferencedDocs(
+                        context,
+                        "Index documents (previously or currently) coupled to service $docId to Elasticsearch",
+                        """
+                        d.uuid IN (
+                            SELECT jsonb_array_elements(data->'service'->'coupledResources')->>'uuid'
+                            FROM document
+                            WHERE uuid = '$docId'
+                                AND version=$version)
+                        """.trimIndent()
+                    )
                 }
             } else if (isAddress) {
                 indexDoc(context, docId, DocumentCategory.ADDRESS)

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/extensions/InGridPublishExport.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/extensions/InGridPublishExport.kt
@@ -46,7 +46,6 @@ class InGridPublishExport(
 
     override val profiles = arrayOf("ingrid")
 
-    @OptIn(DelicateCoroutinesApi::class)
     override fun invoke(payload: PostPublishPayload, context: Context): PostPublishPayload {
         val docId = payload.document.uuid
         val isDocument = payload.wrapper.category == "data"
@@ -99,6 +98,7 @@ class InGridPublishExport(
         return payload
     }
 
+    @OptIn(DelicateCoroutinesApi::class)
     private fun indexReferencedDocs(context: Context, message: String, sqlFilter: String) {
         context.addMessage(Message(this, message))
 

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/extensions/InGridPublishExport.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/extensions/InGridPublishExport.kt
@@ -57,7 +57,7 @@ class InGridPublishExport(
                 indexDoc(context, docId, DocumentCategory.DATA)
                 val dataType = payload.wrapper.type
                 val version = payload.document.version
-                // we cannot use GlobalScope here, because we need data from the previous version
+                // we cannot use GlobalScope directly here, because we need data from the previous version
                 // this can only be reliably determined if we're in the same transaction
                 if (dataType == "InGridGeoDataset") {
                     indexReferencedDocs(
@@ -86,13 +86,11 @@ class InGridPublishExport(
                 }
             } else if (isAddress) {
                 indexDoc(context, docId, DocumentCategory.ADDRESS)
-                GlobalScope.launch {
-                    indexReferencedDocs(
-                        context,
-                        "Index documents with referenced address $docId to Elasticsearch",
-                        """data->'pointOfContact'@>'[{"ref": "$docId"}]'""",
-                    )
-                }
+                indexReferencedDocs(
+                    context,
+                    "Index documents with referenced address $docId to Elasticsearch",
+                    """data->'pointOfContact'@>'[{"ref": "$docId"}]'""",
+                )
             }
         } catch (ex: Exception) {
             throw ClientException.withReason("Problem with indexing to Elasticsearch: ${ex.cause?.message}", ex)
@@ -117,7 +115,10 @@ class InGridPublishExport(
             """.trimIndent(),
         )
 
-        docsWithReferences.forEach { indexDoc(context, it, DocumentCategory.DATA) }
+        // use GlobalScope only for indexing, not for determining which documents to index
+        GlobalScope.launch {
+            docsWithReferences.forEach { indexDoc(context, it, DocumentCategory.DATA) }
+        }
     }
 
     private fun indexDoc(context: Context, docId: String, category: DocumentCategory) {

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/extensions/InGridPublishExport.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/extensions/InGridPublishExport.kt
@@ -58,7 +58,11 @@ class InGridPublishExport(
             } else if (isAddress) {
                 indexDoc(context, docId, DocumentCategory.ADDRESS)
                 GlobalScope.launch {
-                    indexReferencedDocs(context, docId)
+                    indexReferencedDocs(
+                        context,
+                        "Index documents with referenced address $docId to Elasticsearch",
+                        """data->'pointOfContact'@>'[{"ref": "$docId"}]'"""
+                    )
                 }
             }
         } catch (ex: Exception) {
@@ -68,8 +72,8 @@ class InGridPublishExport(
         return payload
     }
 
-    private fun indexReferencedDocs(context: Context, docId: String) {
-        context.addMessage(Message(this, "Index documents with referenced address $docId to Elasticsearch"))
+    private fun indexReferencedDocs(context: Context, message: String, sqlFilter: String) {
+        context.addMessage(Message(this, message))
 
         // get uuids from documents that reference the address
         val docsWithReferences = jdbcTemplate.queryForList<String>(
@@ -80,7 +84,7 @@ class InGridPublishExport(
                 dw.uuid = d.uuid
                 AND d.state = 'PUBLISHED'
                 AND dw.deleted = 0
-                AND data->'pointOfContact' @> '[{"ref": "$docId"}]');
+                AND $sqlFilter);
             """.trimIndent(),
         )
 

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/extensions/InGridPublishExport.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/extensions/InGridPublishExport.kt
@@ -55,6 +55,32 @@ class InGridPublishExport(
         try {
             if (isDocument) {
                 indexDoc(context, docId, DocumentCategory.DATA)
+                val dataType = payload.wrapper.type
+                GlobalScope.launch {
+                    if (dataType == "InGridGeoDataset") {
+                        indexReferencedDocs(
+                            context,
+                            "Index documents referenced by dataset $docId to Elasticsearch",
+                            """
+                            d.uuid IN (
+                                SELECT jsonb_array_elements(data->'references')->>'uuidRef'
+                                FROM document
+                                WHERE uuid = '$docId')
+                            """.trimIndent()
+                        )
+                    } else if (dataType == "InGridGeoService") {
+                        indexReferencedDocs(
+                            context,
+                            "Index documents coupled to service $docId to Elasticsearch",
+                            """
+                            d.uuid IN (
+                                SELECT jsonb_array_elements(data->'service'->'coupledResources')->>'uuid'
+                                FROM document
+                                WHERE uuid = '$docId')
+                            """.trimIndent()
+                        )
+                    }
+                }
             } else if (isAddress) {
                 indexDoc(context, docId, DocumentCategory.ADDRESS)
                 GlobalScope.launch {

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/extensions/InGridPublishExport.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/extensions/InGridPublishExport.kt
@@ -58,19 +58,18 @@ class InGridPublishExport(
                 val version = payload.document.version
                 // we cannot use GlobalScope directly here, because we need data from the previous version
                 // this can only be reliably determined if we're in the same transaction
-                if (dataType == "InGridGeoDataset") {
-                    indexReferencedDocs(
-                        context,
-                        "Index documents (previously or currently) referenced by dataset $docId to Elasticsearch",
-                        """
-                        d.uuid IN (
-                            SELECT jsonb_array_elements(data->'references')->>'uuidRef'
-                            FROM document
-                            WHERE uuid = '$docId'
-                                AND version=$version)
-                        """.trimIndent(),
-                    )
-                } else if (dataType == "InGridGeoService") {
+                indexReferencedDocs(
+                    context,
+                    "Index documents (previously or currently) referenced by dataset $docId to Elasticsearch",
+                    """
+                    d.uuid IN (
+                        SELECT jsonb_array_elements(data->'references')->>'uuidRef'
+                        FROM document
+                        WHERE uuid = '$docId'
+                            AND version=$version)
+                    """.trimIndent(),
+                )
+                if (dataType == "InGridGeoService") {
                     indexReferencedDocs(
                         context,
                         "Index documents (previously or currently) coupled to service $docId to Elasticsearch",

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/extensions/InGridPublishExport.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/extensions/InGridPublishExport.kt
@@ -69,7 +69,7 @@ class InGridPublishExport(
                             FROM document
                             WHERE uuid = '$docId'
                                 AND version=$version)
-                        """.trimIndent()
+                        """.trimIndent(),
                     )
                 } else if (dataType == "InGridGeoService") {
                     indexReferencedDocs(
@@ -81,7 +81,7 @@ class InGridPublishExport(
                             FROM document
                             WHERE uuid = '$docId'
                                 AND version=$version)
-                        """.trimIndent()
+                        """.trimIndent(),
                     )
                 }
             } else if (isAddress) {
@@ -90,7 +90,7 @@ class InGridPublishExport(
                     indexReferencedDocs(
                         context,
                         "Index documents with referenced address $docId to Elasticsearch",
-                        """data->'pointOfContact'@>'[{"ref": "$docId"}]'"""
+                        """data->'pointOfContact'@>'[{"ref": "$docId"}]'""",
                     )
                 }
             }


### PR DESCRIPTION
Neue Funktionalität beim Veröffentlichen von Diensten und Datensätzen eingeführt ([#6963](https://redmine.informationgrid.eu/issues/6963)):

- beim Veröffentlichen von Diensten werden nun auch gekoppelte (veröffentlichte) Datensätze neu indexiert (Kopplung über Fachbezug > Dargestellte Daten)
- beim Veröffentlichen von Datensätzen werden nun auch referenzierte (veröffentlichte) Datensätze indexiert (Referenzierung über Verweise > Interner Datensatz)