### PR TITLE
Add Fallback to ResearchQueryFactory to Handle Missing Profile Customizations

### DIFF
--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
@@ -33,7 +33,7 @@ class OgcApiResearchQueryBmi : OgcApiResearchQuery() {
 
     override lateinit var ogcParameter: OgcFilterParameter // = OgcFilterParameter(null, null, null, null, null, null)
 
-    override fun checkParametersSupport() {}
+    override fun checkForUnsupportedParameters() {}
 
     override fun profileSpecificClauses(): MutableList<BoolFilter>? {
         val clausesList: MutableList<BoolFilter> = mutableListOf()

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
@@ -31,8 +31,6 @@ import org.springframework.stereotype.Component
 class OgcApiResearchQueryBmi : OgcApiResearchQuery() {
     override val profiles = listOf("bmi")
 
-    override fun checkForUnsupportedParameters(ogcFilterParameter: OgcFilterParameter) {}
-
     override fun profileSpecificClauses(ogcParameter: OgcFilterParameter): MutableList<BoolFilter>? {
         val clausesList: MutableList<BoolFilter> = mutableListOf()
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
@@ -24,10 +24,8 @@ import de.ingrid.igeserver.features.ogc_api_records.services.research_query.OgcF
 import de.ingrid.igeserver.model.BoolFilter
 import org.intellij.lang.annotations.Language
 import org.springframework.context.annotation.Profile
-import org.springframework.stereotype.Component
 
 @Profile("bmi")
-@Component
 class OgcApiResearchQueryBmi : OgcApiResearchQuery() {
     override val profiles = listOf("bmi")
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
@@ -33,6 +33,8 @@ class OgcApiResearchQueryBmi : OgcApiResearchQuery() {
 
     override lateinit var ogcParameter: OgcFilterParameter // = OgcFilterParameter(null, null, null, null, null, null)
 
+    override fun checkParametersSupport() {}
+
     override fun profileSpecificClauses(): MutableList<BoolFilter>? {
         val clausesList: MutableList<BoolFilter> = mutableListOf()
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
@@ -24,8 +24,10 @@ import de.ingrid.igeserver.features.ogc_api_records.services.research_query.OgcF
 import de.ingrid.igeserver.model.BoolFilter
 import org.intellij.lang.annotations.Language
 import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
 
 @Profile("bmi")
+@Component
 class OgcApiResearchQueryBmi : OgcApiResearchQuery() {
     override val profiles = listOf("bmi")
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
@@ -39,18 +39,18 @@ class OgcApiResearchQueryBmi : OgcApiResearchQuery() {
             clausesList.add(BoolFilter("OR", listOf("ingridSelectSpatial"), null, boundingBox, true))
         }
 
-        if (ogcParameter.q != null) {
-            clausesList.add(BoolFilter("OR", listOf(qParameterSQL(ogcParameter)), null, null, false))
+        ogcParameter.q?.let { qParameter ->
+            clausesList.add(BoolFilter("OR", listOf(qParameterSQL(qParameter)), null, null, false))
         }
 
         return clausesList
     }
 
     @Language("PostgreSQL")
-    private fun qParameterSQL(ogcParameter: OgcFilterParameter): String {
-        val titleCondition = ogcParameter.q?.joinToString(" OR ") { "title ILIKE '%$it%'" }
-        val descriptionCondition = ogcParameter.q?.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
-        val keywordsCondition = ogcParameter.q?.joinToString(" OR ") { "data ->> 'keywords' ILIKE '%$it%'" }
+    private fun qParameterSQL(qParameter: List<String>): String {
+        val titleCondition = qParameter.joinToString(" OR ") { "title ILIKE '%$it%'" }
+        val descriptionCondition = qParameter.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
+        val keywordsCondition = qParameter.joinToString(" OR ") { "data ->> 'keywords' ILIKE '%$it%'" }
 
         return """
             ($titleCondition) 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
@@ -36,6 +36,11 @@ class OgcApiResearchQueryBmi : OgcApiResearchQuery() {
     override fun profileSpecificClauses(): MutableList<BoolFilter>? {
         val clausesList: MutableList<BoolFilter> = mutableListOf()
 
+        ogcParameter.bbox?.let { bbox ->
+            val boundingBox = bbox.map { coordinate -> coordinate.toString() }
+            clausesList.add(BoolFilter("OR", listOf("ingridSelectSpatial"), null, boundingBox, true))
+        }
+
         if (ogcParameter.qParameter != null) {
             clausesList.add(BoolFilter("OR", listOf(qParameterSQL()), null, null, false))
         }
@@ -44,7 +49,7 @@ class OgcApiResearchQueryBmi : OgcApiResearchQuery() {
     }
 
     @Language("PostgreSQL")
-    fun qParameterSQL(): String {
+    private fun qParameterSQL(): String {
         val titleCondition = ogcParameter.qParameter?.joinToString(" OR ") { "title ILIKE '%$it%'" }
         val descriptionCondition = ogcParameter.qParameter?.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
         val keywordsCondition = ogcParameter.qParameter?.joinToString(" OR ") { "data ->> 'keywords' ILIKE '%$it%'" }

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
@@ -39,7 +39,7 @@ class OgcApiResearchQueryBmi : OgcApiResearchQuery() {
             clausesList.add(BoolFilter("OR", listOf("ingridSelectSpatial"), null, boundingBox, true))
         }
 
-        if (ogcParameter.qParameter != null) {
+        if (ogcParameter.q != null) {
             clausesList.add(BoolFilter("OR", listOf(qParameterSQL(ogcParameter)), null, null, false))
         }
 
@@ -48,9 +48,9 @@ class OgcApiResearchQueryBmi : OgcApiResearchQuery() {
 
     @Language("PostgreSQL")
     private fun qParameterSQL(ogcParameter: OgcFilterParameter): String {
-        val titleCondition = ogcParameter.qParameter?.joinToString(" OR ") { "title ILIKE '%$it%'" }
-        val descriptionCondition = ogcParameter.qParameter?.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
-        val keywordsCondition = ogcParameter.qParameter?.joinToString(" OR ") { "data ->> 'keywords' ILIKE '%$it%'" }
+        val titleCondition = ogcParameter.q?.joinToString(" OR ") { "title ILIKE '%$it%'" }
+        val descriptionCondition = ogcParameter.q?.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
+        val keywordsCondition = ogcParameter.q?.joinToString(" OR ") { "data ->> 'keywords' ILIKE '%$it%'" }
 
         return """
             ($titleCondition) 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/bmi/OgcApiResearchQueryBmi.kt
@@ -31,11 +31,9 @@ import org.springframework.stereotype.Component
 class OgcApiResearchQueryBmi : OgcApiResearchQuery() {
     override val profiles = listOf("bmi")
 
-    override lateinit var ogcParameter: OgcFilterParameter // = OgcFilterParameter(null, null, null, null, null, null)
+    override fun checkForUnsupportedParameters(ogcFilterParameter: OgcFilterParameter) {}
 
-    override fun checkForUnsupportedParameters() {}
-
-    override fun profileSpecificClauses(): MutableList<BoolFilter>? {
+    override fun profileSpecificClauses(ogcParameter: OgcFilterParameter): MutableList<BoolFilter>? {
         val clausesList: MutableList<BoolFilter> = mutableListOf()
 
         ogcParameter.bbox?.let { bbox ->
@@ -44,14 +42,14 @@ class OgcApiResearchQueryBmi : OgcApiResearchQuery() {
         }
 
         if (ogcParameter.qParameter != null) {
-            clausesList.add(BoolFilter("OR", listOf(qParameterSQL()), null, null, false))
+            clausesList.add(BoolFilter("OR", listOf(qParameterSQL(ogcParameter)), null, null, false))
         }
 
         return clausesList
     }
 
     @Language("PostgreSQL")
-    private fun qParameterSQL(): String {
+    private fun qParameterSQL(ogcParameter: OgcFilterParameter): String {
         val titleCondition = ogcParameter.qParameter?.joinToString(" OR ") { "title ILIKE '%$it%'" }
         val descriptionCondition = ogcParameter.qParameter?.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
         val keywordsCondition = ogcParameter.qParameter?.joinToString(" OR ") { "data ->> 'keywords' ILIKE '%$it%'" }

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
@@ -31,8 +31,6 @@ import org.springframework.stereotype.Component
 class OgcApiResearchQueryIngrid : OgcApiResearchQuery() {
     override val profiles = listOf("ingrid", "ingrid-hmdk")
 
-    override fun checkForUnsupportedParameters(ogcFilterParameter: OgcFilterParameter) {}
-
     override fun profileSpecificClauses(ogcParameter: OgcFilterParameter): MutableList<BoolFilter>? {
         val clausesList: MutableList<BoolFilter> = mutableListOf()
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
@@ -33,6 +33,8 @@ class OgcApiResearchQueryIngrid : OgcApiResearchQuery() {
 
     override lateinit var ogcParameter: OgcFilterParameter
 
+    override fun checkParametersSupport() {}
+
     override fun profileSpecificClauses(): MutableList<BoolFilter>? {
         val clausesList: MutableList<BoolFilter> = mutableListOf()
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
@@ -39,19 +39,19 @@ class OgcApiResearchQueryIngrid : OgcApiResearchQuery() {
             clausesList.add(BoolFilter("OR", listOf("ingridSelectSpatial"), null, boundingBox, true))
         }
 
-        if (ogcParameter.q != null) {
-            clausesList.add(BoolFilter("OR", listOf(qParameterSQL(ogcParameter)), null, null, false))
+        ogcParameter.q?.let { qParameter ->
+            clausesList.add(BoolFilter("OR", listOf(qParameterSQL(qParameter)), null, null, false))
         }
 
         return clausesList
     }
 
     @Language("PostgreSQL")
-    private fun qParameterSQL(ogcParameter: OgcFilterParameter): String {
-        val titleCondition = ogcParameter.q?.joinToString(" OR ") { "title ILIKE '%$it%'" }
-        val descriptionCondition = ogcParameter.q?.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
-        val alternateTitleCondition = ogcParameter.q?.joinToString(" OR ") { "data ->> 'alternateTitle' ILIKE '%$it%'" }
-        val freeKeywordsCondition = ogcParameter.q?.joinToString(" OR ") { "EXISTS (SELECT 1 FROM jsonb_array_elements(data -> 'keywords' -> 'free') AS keyword WHERE keyword ->> 'label' ILIKE '%$it%')" }
+    private fun qParameterSQL(qParameter: List<String>): String {
+        val titleCondition = qParameter.joinToString(" OR ") { "title ILIKE '%$it%'" }
+        val descriptionCondition = qParameter.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
+        val alternateTitleCondition = qParameter.joinToString(" OR ") { "data ->> 'alternateTitle' ILIKE '%$it%'" }
+        val freeKeywordsCondition = qParameter.joinToString(" OR ") { "EXISTS (SELECT 1 FROM jsonb_array_elements(data -> 'keywords' -> 'free') AS keyword WHERE keyword ->> 'label' ILIKE '%$it%')" }
 
         return """
             ($titleCondition)

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
@@ -33,7 +33,7 @@ class OgcApiResearchQueryIngrid : OgcApiResearchQuery() {
 
     override lateinit var ogcParameter: OgcFilterParameter
 
-    override fun checkParametersSupport() {}
+    override fun checkForUnsupportedParameters() {}
 
     override fun profileSpecificClauses(): MutableList<BoolFilter>? {
         val clausesList: MutableList<BoolFilter> = mutableListOf()

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
@@ -24,8 +24,10 @@ import de.ingrid.igeserver.features.ogc_api_records.services.research_query.OgcF
 import de.ingrid.igeserver.model.BoolFilter
 import org.intellij.lang.annotations.Language
 import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
 
 @Profile("ingrid | ingrid-hmdk")
+@Component
 class OgcApiResearchQueryIngrid : OgcApiResearchQuery() {
     override val profiles = listOf("ingrid", "ingrid-hmdk")
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
@@ -31,11 +31,9 @@ import org.springframework.stereotype.Component
 class OgcApiResearchQueryIngrid : OgcApiResearchQuery() {
     override val profiles = listOf("ingrid", "ingrid-hmdk")
 
-    override lateinit var ogcParameter: OgcFilterParameter
+    override fun checkForUnsupportedParameters(ogcFilterParameter: OgcFilterParameter) {}
 
-    override fun checkForUnsupportedParameters() {}
-
-    override fun profileSpecificClauses(): MutableList<BoolFilter>? {
+    override fun profileSpecificClauses(ogcParameter: OgcFilterParameter): MutableList<BoolFilter>? {
         val clausesList: MutableList<BoolFilter> = mutableListOf()
 
         ogcParameter.bbox?.let { bbox ->
@@ -44,14 +42,14 @@ class OgcApiResearchQueryIngrid : OgcApiResearchQuery() {
         }
 
         if (ogcParameter.qParameter != null) {
-            clausesList.add(BoolFilter("OR", listOf(qParameterSQL()), null, null, false))
+            clausesList.add(BoolFilter("OR", listOf(qParameterSQL(ogcParameter)), null, null, false))
         }
 
         return clausesList
     }
 
     @Language("PostgreSQL")
-    private fun qParameterSQL(): String {
+    private fun qParameterSQL(ogcParameter: OgcFilterParameter): String {
         val titleCondition = ogcParameter.qParameter?.joinToString(" OR ") { "title ILIKE '%$it%'" }
         val descriptionCondition = ogcParameter.qParameter?.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
         val alternateTitleCondition = ogcParameter.qParameter?.joinToString(" OR ") { "data ->> 'alternateTitle' ILIKE '%$it%'" }

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
@@ -24,10 +24,8 @@ import de.ingrid.igeserver.features.ogc_api_records.services.research_query.OgcF
 import de.ingrid.igeserver.model.BoolFilter
 import org.intellij.lang.annotations.Language
 import org.springframework.context.annotation.Profile
-import org.springframework.stereotype.Component
 
 @Profile("ingrid | ingrid-hmdk")
-@Component
 class OgcApiResearchQueryIngrid : OgcApiResearchQuery() {
     override val profiles = listOf("ingrid", "ingrid-hmdk")
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
@@ -36,6 +36,11 @@ class OgcApiResearchQueryIngrid : OgcApiResearchQuery() {
     override fun profileSpecificClauses(): MutableList<BoolFilter>? {
         val clausesList: MutableList<BoolFilter> = mutableListOf()
 
+        ogcParameter.bbox?.let { bbox ->
+            val boundingBox = bbox.map { coordinate -> coordinate.toString() }
+            clausesList.add(BoolFilter("OR", listOf("ingridSelectSpatial"), null, boundingBox, true))
+        }
+
         if (ogcParameter.qParameter != null) {
             clausesList.add(BoolFilter("OR", listOf(qParameterSQL()), null, null, false))
         }
@@ -44,7 +49,7 @@ class OgcApiResearchQueryIngrid : OgcApiResearchQuery() {
     }
 
     @Language("PostgreSQL")
-    fun qParameterSQL(): String {
+    private fun qParameterSQL(): String {
         val titleCondition = ogcParameter.qParameter?.joinToString(" OR ") { "title ILIKE '%$it%'" }
         val descriptionCondition = ogcParameter.qParameter?.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
         val alternateTitleCondition = ogcParameter.qParameter?.joinToString(" OR ") { "data ->> 'alternateTitle' ILIKE '%$it%'" }

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/ingrid/OgcApiResearchQueryIngrid.kt
@@ -39,7 +39,7 @@ class OgcApiResearchQueryIngrid : OgcApiResearchQuery() {
             clausesList.add(BoolFilter("OR", listOf("ingridSelectSpatial"), null, boundingBox, true))
         }
 
-        if (ogcParameter.qParameter != null) {
+        if (ogcParameter.q != null) {
             clausesList.add(BoolFilter("OR", listOf(qParameterSQL(ogcParameter)), null, null, false))
         }
 
@@ -48,10 +48,10 @@ class OgcApiResearchQueryIngrid : OgcApiResearchQuery() {
 
     @Language("PostgreSQL")
     private fun qParameterSQL(ogcParameter: OgcFilterParameter): String {
-        val titleCondition = ogcParameter.qParameter?.joinToString(" OR ") { "title ILIKE '%$it%'" }
-        val descriptionCondition = ogcParameter.qParameter?.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
-        val alternateTitleCondition = ogcParameter.qParameter?.joinToString(" OR ") { "data ->> 'alternateTitle' ILIKE '%$it%'" }
-        val freeKeywordsCondition = ogcParameter.qParameter?.joinToString(" OR ") { "EXISTS (SELECT 1 FROM jsonb_array_elements(data -> 'keywords' -> 'free') AS keyword WHERE keyword ->> 'label' ILIKE '%$it%')" }
+        val titleCondition = ogcParameter.q?.joinToString(" OR ") { "title ILIKE '%$it%'" }
+        val descriptionCondition = ogcParameter.q?.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
+        val alternateTitleCondition = ogcParameter.q?.joinToString(" OR ") { "data ->> 'alternateTitle' ILIKE '%$it%'" }
+        val freeKeywordsCondition = ogcParameter.q?.joinToString(" OR ") { "EXISTS (SELECT 1 FROM jsonb_array_elements(data -> 'keywords' -> 'free') AS keyword WHERE keyword ->> 'label' ILIKE '%$it%')" }
 
         return """
             ($titleCondition)

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
@@ -24,10 +24,8 @@ import de.ingrid.igeserver.features.ogc_api_records.services.research_query.OgcF
 import de.ingrid.igeserver.model.BoolFilter
 import org.intellij.lang.annotations.Language
 import org.springframework.context.annotation.Profile
-import org.springframework.stereotype.Component
 
 @Profile("uvp")
-@Component
 class OgcApiResearchQueryUvp : OgcApiResearchQuery() {
     override val profiles = listOf("uvp")
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
@@ -39,17 +39,17 @@ class OgcApiResearchQueryUvp : OgcApiResearchQuery() {
             clausesList.add(BoolFilter("OR", listOf("ingridSelectSpatial"), null, boundingBox, true))
         }
 
-        if (ogcParameter.q != null) {
-            clausesList.add(BoolFilter("OR", listOf(qParameterSQL(ogcParameter)), null, null, false))
+        ogcParameter.q?.let { qParameter ->
+            clausesList.add(BoolFilter("OR", listOf(qParameterSQL(qParameter)), null, null, false))
         }
 
         return clausesList
     }
 
     @Language("PostgreSQL")
-    private fun qParameterSQL(ogcParameter: OgcFilterParameter): String {
-        val titleCondition = ogcParameter.q?.joinToString(" OR ") { "title ILIKE '%$it%'" }
-        val descriptionCondition = ogcParameter.q?.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
+    private fun qParameterSQL(qParameter: List<String>): String {
+        val titleCondition = qParameter.joinToString(" OR ") { "title ILIKE '%$it%'" }
+        val descriptionCondition = qParameter.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
 
         return """
             ($titleCondition)

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
@@ -36,6 +36,11 @@ class OgcApiResearchQueryUvp : OgcApiResearchQuery() {
     override fun profileSpecificClauses(): MutableList<BoolFilter>? {
         val clausesList: MutableList<BoolFilter> = mutableListOf()
 
+        ogcParameter.bbox?.let { bbox ->
+            val boundingBox = bbox.map { coordinate -> coordinate.toString() }
+            clausesList.add(BoolFilter("OR", listOf("ingridSelectSpatial"), null, boundingBox, true))
+        }
+
         if (ogcParameter.qParameter != null) {
             clausesList.add(BoolFilter("OR", listOf(qParameterSQL()), null, null, false))
         }
@@ -44,7 +49,7 @@ class OgcApiResearchQueryUvp : OgcApiResearchQuery() {
     }
 
     @Language("PostgreSQL")
-    fun qParameterSQL(): String {
+    private fun qParameterSQL(): String {
         val titleCondition = ogcParameter.qParameter?.joinToString(" OR ") { "title ILIKE '%$it%'" }
         val descriptionCondition = ogcParameter.qParameter?.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
@@ -33,6 +33,8 @@ class OgcApiResearchQueryUvp : OgcApiResearchQuery() {
 
     override lateinit var ogcParameter: OgcFilterParameter
 
+    override fun checkParametersSupport() {}
+
     override fun profileSpecificClauses(): MutableList<BoolFilter>? {
         val clausesList: MutableList<BoolFilter> = mutableListOf()
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
@@ -31,8 +31,6 @@ import org.springframework.stereotype.Component
 class OgcApiResearchQueryUvp : OgcApiResearchQuery() {
     override val profiles = listOf("uvp")
 
-    override fun checkForUnsupportedParameters(ogcFilterParameter: OgcFilterParameter) {}
-
     override fun profileSpecificClauses(ogcParameter: OgcFilterParameter): MutableList<BoolFilter>? {
         val clausesList: MutableList<BoolFilter> = mutableListOf()
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
@@ -33,7 +33,7 @@ class OgcApiResearchQueryUvp : OgcApiResearchQuery() {
 
     override lateinit var ogcParameter: OgcFilterParameter
 
-    override fun checkParametersSupport() {}
+    override fun checkForUnsupportedParameters() {}
 
     override fun profileSpecificClauses(): MutableList<BoolFilter>? {
         val clausesList: MutableList<BoolFilter> = mutableListOf()

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
@@ -39,7 +39,7 @@ class OgcApiResearchQueryUvp : OgcApiResearchQuery() {
             clausesList.add(BoolFilter("OR", listOf("ingridSelectSpatial"), null, boundingBox, true))
         }
 
-        if (ogcParameter.qParameter != null) {
+        if (ogcParameter.q != null) {
             clausesList.add(BoolFilter("OR", listOf(qParameterSQL(ogcParameter)), null, null, false))
         }
 
@@ -48,8 +48,8 @@ class OgcApiResearchQueryUvp : OgcApiResearchQuery() {
 
     @Language("PostgreSQL")
     private fun qParameterSQL(ogcParameter: OgcFilterParameter): String {
-        val titleCondition = ogcParameter.qParameter?.joinToString(" OR ") { "title ILIKE '%$it%'" }
-        val descriptionCondition = ogcParameter.qParameter?.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
+        val titleCondition = ogcParameter.q?.joinToString(" OR ") { "title ILIKE '%$it%'" }
+        val descriptionCondition = ogcParameter.q?.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
 
         return """
             ($titleCondition)

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
@@ -24,8 +24,10 @@ import de.ingrid.igeserver.features.ogc_api_records.services.research_query.OgcF
 import de.ingrid.igeserver.model.BoolFilter
 import org.intellij.lang.annotations.Language
 import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
 
 @Profile("uvp")
+@Component
 class OgcApiResearchQueryUvp : OgcApiResearchQuery() {
     override val profiles = listOf("uvp")
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/profiles/uvp/OgcApiResearchQueryUvp.kt
@@ -31,11 +31,9 @@ import org.springframework.stereotype.Component
 class OgcApiResearchQueryUvp : OgcApiResearchQuery() {
     override val profiles = listOf("uvp")
 
-    override lateinit var ogcParameter: OgcFilterParameter
+    override fun checkForUnsupportedParameters(ogcFilterParameter: OgcFilterParameter) {}
 
-    override fun checkForUnsupportedParameters() {}
-
-    override fun profileSpecificClauses(): MutableList<BoolFilter>? {
+    override fun profileSpecificClauses(ogcParameter: OgcFilterParameter): MutableList<BoolFilter>? {
         val clausesList: MutableList<BoolFilter> = mutableListOf()
 
         ogcParameter.bbox?.let { bbox ->
@@ -44,14 +42,14 @@ class OgcApiResearchQueryUvp : OgcApiResearchQuery() {
         }
 
         if (ogcParameter.qParameter != null) {
-            clausesList.add(BoolFilter("OR", listOf(qParameterSQL()), null, null, false))
+            clausesList.add(BoolFilter("OR", listOf(qParameterSQL(ogcParameter)), null, null, false))
         }
 
         return clausesList
     }
 
     @Language("PostgreSQL")
-    private fun qParameterSQL(): String {
+    private fun qParameterSQL(ogcParameter: OgcFilterParameter): String {
         val titleCondition = ogcParameter.qParameter?.joinToString(" OR ") { "title ILIKE '%$it%'" }
         val descriptionCondition = ogcParameter.qParameter?.joinToString(" OR ") { "data ->> 'description' ILIKE '%$it%'" }
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchFallback.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchFallback.kt
@@ -17,7 +17,6 @@
  * See the Licence for the specific language governing permissions and
  * limitations under the Licence.
  */
-
 package de.ingrid.igeserver.features.ogc_api_records.services.research_query
 
 import de.ingrid.igeserver.configuration.ConfigurationException

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchFallback.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchFallback.kt
@@ -1,0 +1,39 @@
+/**
+ * ==================================================
+ * Copyright (C) 2024-2025 wemove digital solutions GmbH
+ * ==================================================
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be
+ * approved by the European Commission - subsequent versions of the
+ * EUPL (the "Licence");
+ *
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package de.ingrid.igeserver.features.ogc_api_records.services.research_query
+
+import de.ingrid.igeserver.configuration.ConfigurationException
+import de.ingrid.igeserver.model.BoolFilter
+import org.springframework.stereotype.Component
+
+@Component
+class OgcApiResearchFallback : OgcApiResearchQuery() {
+    override val profiles = listOf("fallback")
+
+    override lateinit var ogcParameter: OgcFilterParameter
+
+    override fun profileSpecificClauses(): MutableList<BoolFilter>? {
+        if (ogcParameter.qParameter != null) {
+            throw ConfigurationException.withReason("Request parameter 'q' is not yet supported for current profile. Please remove the parameter.")
+        }
+        return null
+    }
+}

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
@@ -33,7 +33,7 @@ data class OgcFilterParameter(
     val type: List<String>?,
     val bbox: List<Float>?,
     val datetime: String?,
-    val qParameter: List<String>?,
+    val q: List<String>?,
 )
 
 abstract class OgcApiResearchQuery {

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
@@ -37,11 +37,9 @@ data class OgcFilterParameter(
 abstract class OgcApiResearchQuery {
     abstract val profiles: List<String>
 
-    abstract var ogcParameter: OgcFilterParameter
+    abstract fun checkForUnsupportedParameters(ogcFilterParameter: OgcFilterParameter)
 
-    abstract fun checkForUnsupportedParameters()
-
-    abstract fun profileSpecificClauses(): MutableList<BoolFilter>?
+    abstract fun profileSpecificClauses(ogcParameter: OgcFilterParameter): MutableList<BoolFilter>?
 
     fun profiles(): List<String> = profiles
 
@@ -79,18 +77,17 @@ abstract class OgcApiResearchQuery {
             clausesList.add(BoolFilter("OR", typeList, null, null, false))
         }
 
-        profileSpecificClauses()?.let { clausesList.addAll(it) }
+        profileSpecificClauses(ogcParameter)?.let { clausesList.addAll(it) }
 
         return clausesList
     }
 
     fun createQuery(ogcFilterParameter: OgcFilterParameter): ResearchQuery {
-        ogcParameter = ogcFilterParameter
-        checkForUnsupportedParameters()
+        checkForUnsupportedParameters(ogcFilterParameter)
         return ResearchQuery(
             term = null,
             clauses = BoolFilter(op = "AND", value = null, clauses = clauses(ogcFilterParameter), parameter = null, isFacet = true),
-            pagination = ResearchPaging(1, ogcParameter.queryLimit, ogcParameter.queryOffset),
+            pagination = ResearchPaging(1, ogcFilterParameter.queryLimit, ogcFilterParameter.queryOffset),
         )
     }
 }

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
@@ -20,10 +20,12 @@
 package de.ingrid.igeserver.features.ogc_api_records.services.research_query
 
 import de.ingrid.igeserver.ClientException
+import de.ingrid.igeserver.configuration.ConfigurationException
 import de.ingrid.igeserver.model.BoolFilter
 import de.ingrid.igeserver.model.ResearchPaging
 import de.ingrid.igeserver.model.ResearchQuery
 import java.time.Instant
+import kotlin.reflect.full.memberProperties
 
 data class OgcFilterParameter(
     val queryLimit: Int,
@@ -37,7 +39,16 @@ data class OgcFilterParameter(
 abstract class OgcApiResearchQuery {
     abstract val profiles: List<String>
 
-    abstract fun checkForUnsupportedParameters(ogcFilterParameter: OgcFilterParameter)
+    open var unsupportedParameters: List<String> = listOf()
+
+    private fun checkForUnsupportedParameters(ogcFilterParameter: OgcFilterParameter) {
+        unsupportedParameters.forEach { unsupportedParameter ->
+            val property = OgcFilterParameter::class.memberProperties.find { it.name == unsupportedParameter }
+            property?.get(ogcFilterParameter)?.let {
+                throw ConfigurationException.withReason("Request parameter '$unsupportedParameter' is not yet supported for current profile. Please remove the parameter.")
+            }
+        }
+    }
 
     abstract fun profileSpecificClauses(ogcParameter: OgcFilterParameter): MutableList<BoolFilter>?
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
@@ -39,7 +39,7 @@ abstract class OgcApiResearchQuery {
 
     abstract var ogcParameter: OgcFilterParameter
 
-    abstract fun checkParametersSupport()
+    abstract fun checkForUnsupportedParameters()
 
     abstract fun profileSpecificClauses(): MutableList<BoolFilter>?
 
@@ -87,7 +87,7 @@ abstract class OgcApiResearchQuery {
 
     fun createQuery(ogcFilterParameter: OgcFilterParameter): ResearchQuery {
         ogcParameter = ogcFilterParameter
-        checkParametersSupport()
+        checkForUnsupportedParameters()
         return ResearchQuery(
             term = null,
             clauses = BoolFilter(op = "AND", value = null, clauses = clauses(ogcFilterParameter), parameter = null, isFacet = true),

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
@@ -85,11 +85,7 @@ abstract class OgcApiResearchQuery {
             clausesList.add(BoolFilter("OR", typeList, null, null, false))
         }
 
-        val profileSpecificClausesList = profileSpecificClauses()
-
-        if (profileSpecificClausesList != null) {
-            clausesList.addAll(profileSpecificClausesList)
-        }
+        profileSpecificClauses()?.let { clausesList.addAll(it) }
 
         return clausesList
     }

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
@@ -43,11 +43,15 @@ abstract class OgcApiResearchQuery {
 
     private fun checkForUnsupportedParameters(ogcFilterParameter: OgcFilterParameter) {
         unsupportedParameters.forEach { unsupportedParameter ->
-            val property = OgcFilterParameter::class.memberProperties.find { it.name == unsupportedParameter }
-            property?.get(ogcFilterParameter)?.let {
+            if (unallowedParameterExists(ogcFilterParameter, unsupportedParameter)) {
                 throw ConfigurationException.withReason("Request parameter '$unsupportedParameter' is not yet supported for current profile. Please remove the parameter.")
             }
         }
+    }
+
+    private fun unallowedParameterExists(ogcFilterParameter: OgcFilterParameter, unsupportedParameter: String): Boolean {
+        val property = OgcFilterParameter::class.memberProperties.find { it.name == unsupportedParameter }
+        return property?.get(ogcFilterParameter) != null
     }
 
     abstract fun profileSpecificClauses(ogcParameter: OgcFilterParameter): MutableList<BoolFilter>?
@@ -79,13 +83,11 @@ abstract class OgcApiResearchQuery {
         clausesList.add(BoolFilter("OR", listOf("document1.state = 'PUBLISHED'"), null, null, false))
 
         ogcParameter.datetime?.let { datetime ->
-            val dateList = ogcDateTimeConverter(datetime)
-            clausesList.add(BoolFilter("OR", listOf("selectTimespan"), null, dateList, true))
+            clausesList.add(BoolFilter("OR", listOf("selectTimespan"), null, ogcDateTimeConverter(datetime), true))
         }
 
         ogcParameter.type?.let { type ->
-            val typeList = type.map { "document_wrapper.type = '$it'" }
-            clausesList.add(BoolFilter("OR", typeList, null, null, false))
+            clausesList.add(BoolFilter("OR", type.map { "document_wrapper.type = '$it'" }, null, null, false))
         }
 
         profileSpecificClauses(ogcParameter)?.let { clausesList.addAll(it) }

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
@@ -75,8 +75,7 @@ abstract class OgcApiResearchQuery {
         }
 
         ogcParameter.type?.let { type ->
-            val typeList = mutableListOf<String>()
-            for (name in type) typeList.add("document_wrapper.type = '$name'")
+            val typeList = type.map { "document_wrapper.type = '$it'" }
             clausesList.add(BoolFilter("OR", typeList, null, null, false))
         }
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
@@ -39,6 +39,8 @@ abstract class OgcApiResearchQuery {
 
     abstract var ogcParameter: OgcFilterParameter
 
+    abstract fun checkParametersSupport()
+
     abstract fun profileSpecificClauses(): MutableList<BoolFilter>?
 
     fun profiles(): List<String> = profiles
@@ -67,17 +69,14 @@ abstract class OgcApiResearchQuery {
 
         clausesList.add(BoolFilter("OR", listOf("document1.state = 'PUBLISHED'"), null, null, false))
 
-        // time span
-        if (ogcParameter.datetime != null) {
-            val dateList = ogcDateTimeConverter(ogcParameter.datetime)
+        ogcParameter.datetime?.let { datetime ->
+            val dateList = ogcDateTimeConverter(datetime)
             clausesList.add(BoolFilter("OR", listOf("selectTimespan"), null, dateList, true))
         }
-        // filter by doc type
-        if (ogcParameter.type != null) {
+
+        ogcParameter.type?.let { type ->
             val typeList = mutableListOf<String>()
-            for (name in ogcParameter.type) {
-                typeList.add("document_wrapper.type = '$name'")
-            }
+            for (name in type) typeList.add("document_wrapper.type = '$name'")
             clausesList.add(BoolFilter("OR", typeList, null, null, false))
         }
 
@@ -88,6 +87,7 @@ abstract class OgcApiResearchQuery {
 
     fun createQuery(ogcFilterParameter: OgcFilterParameter): ResearchQuery {
         ogcParameter = ogcFilterParameter
+        checkParametersSupport()
         return ResearchQuery(
             term = null,
             clauses = BoolFilter(op = "AND", value = null, clauses = clauses(ogcFilterParameter), parameter = null, isFacet = true),

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQuery.kt
@@ -66,11 +66,7 @@ abstract class OgcApiResearchQuery {
         clausesList.add(BoolFilter("OR", listOf("exceptFolders"), null, null, true))
 
         clausesList.add(BoolFilter("OR", listOf("document1.state = 'PUBLISHED'"), null, null, false))
-        // bbox // check if 4 values is true
-        if (ogcParameter.bbox != null) {
-            val boundingBox = ogcParameter.bbox.map { coordinate -> coordinate.toString() }
-            clausesList.add(BoolFilter("OR", listOf("ingridSelectSpatial"), null, boundingBox, true))
-        }
+
         // time span
         if (ogcParameter.datetime != null) {
             val dateList = ogcDateTimeConverter(ogcParameter.datetime)

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryDefault.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryDefault.kt
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component
 class OgcApiResearchQueryDefault : OgcApiResearchQuery() {
     override val profiles = listOf("")
 
-    override var unsupportedParameters: List<String> = listOf("qParameter", "bbox")
+    override var unsupportedParameters: List<String> = listOf("q", "bbox")
 
     override fun profileSpecificClauses(ogcParameter: OgcFilterParameter): MutableList<BoolFilter>? = null
 }

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryDefault.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryDefault.kt
@@ -19,7 +19,6 @@
  */
 package de.ingrid.igeserver.features.ogc_api_records.services.research_query
 
-import de.ingrid.igeserver.configuration.ConfigurationException
 import de.ingrid.igeserver.model.BoolFilter
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
@@ -29,10 +28,7 @@ import org.springframework.stereotype.Component
 class OgcApiResearchQueryDefault : OgcApiResearchQuery() {
     override val profiles = listOf("")
 
-    override fun checkForUnsupportedParameters(ogcFilterParameter: OgcFilterParameter) {
-        ogcFilterParameter.qParameter?.let { throw ConfigurationException.withReason("Request parameter 'q' is not yet supported for current profile. Please remove the parameter.") }
-        ogcFilterParameter.bbox?.let { throw ConfigurationException.withReason("Request parameter 'bbox' is not yet supported for current profile. Please remove the parameter.") }
-    }
+    override var unsupportedParameters: List<String> = listOf("qParameter", "bbox")
 
     override fun profileSpecificClauses(ogcParameter: OgcFilterParameter): MutableList<BoolFilter>? = null
 }

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryDefault.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryDefault.kt
@@ -21,7 +21,11 @@ package de.ingrid.igeserver.features.ogc_api_records.services.research_query
 
 import de.ingrid.igeserver.configuration.ConfigurationException
 import de.ingrid.igeserver.model.BoolFilter
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
 
+@Component
+@Qualifier("default")
 class OgcApiResearchQueryDefault : OgcApiResearchQuery() {
     override val profiles = listOf("")
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryDefault.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryDefault.kt
@@ -31,7 +31,7 @@ class OgcApiResearchQueryDefault : OgcApiResearchQuery() {
 
     override lateinit var ogcParameter: OgcFilterParameter
 
-    override fun checkParametersSupport() {
+    override fun checkForUnsupportedParameters() {
         ogcParameter.qParameter?.let { throw ConfigurationException.withReason("Request parameter 'q' is not yet supported for current profile. Please remove the parameter.") }
         ogcParameter.bbox?.let { throw ConfigurationException.withReason("Request parameter 'bbox' is not yet supported for current profile. Please remove the parameter.") }
     }

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryDefault.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryDefault.kt
@@ -21,11 +21,13 @@ package de.ingrid.igeserver.features.ogc_api_records.services.research_query
 
 import de.ingrid.igeserver.configuration.ConfigurationException
 import de.ingrid.igeserver.model.BoolFilter
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 
 @Component
-class OgcApiResearchFallback : OgcApiResearchQuery() {
-    override val profiles = listOf("fallback")
+@Qualifier("default")
+class OgcApiResearchQueryDefault : OgcApiResearchQuery() {
+    override val profiles = listOf("")
 
     override lateinit var ogcParameter: OgcFilterParameter
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryDefault.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryDefault.kt
@@ -29,12 +29,10 @@ import org.springframework.stereotype.Component
 class OgcApiResearchQueryDefault : OgcApiResearchQuery() {
     override val profiles = listOf("")
 
-    override lateinit var ogcParameter: OgcFilterParameter
-
-    override fun checkForUnsupportedParameters() {
-        ogcParameter.qParameter?.let { throw ConfigurationException.withReason("Request parameter 'q' is not yet supported for current profile. Please remove the parameter.") }
-        ogcParameter.bbox?.let { throw ConfigurationException.withReason("Request parameter 'bbox' is not yet supported for current profile. Please remove the parameter.") }
+    override fun checkForUnsupportedParameters(ogcFilterParameter: OgcFilterParameter) {
+        ogcFilterParameter.qParameter?.let { throw ConfigurationException.withReason("Request parameter 'q' is not yet supported for current profile. Please remove the parameter.") }
+        ogcFilterParameter.bbox?.let { throw ConfigurationException.withReason("Request parameter 'bbox' is not yet supported for current profile. Please remove the parameter.") }
     }
 
-    override fun profileSpecificClauses(): MutableList<BoolFilter>? = null
+    override fun profileSpecificClauses(ogcParameter: OgcFilterParameter): MutableList<BoolFilter>? = null
 }

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryDefault.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryDefault.kt
@@ -21,11 +21,7 @@ package de.ingrid.igeserver.features.ogc_api_records.services.research_query
 
 import de.ingrid.igeserver.configuration.ConfigurationException
 import de.ingrid.igeserver.model.BoolFilter
-import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.stereotype.Component
 
-@Component
-@Qualifier("default")
 class OgcApiResearchQueryDefault : OgcApiResearchQuery() {
     override val profiles = listOf("")
 

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryDefault.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryDefault.kt
@@ -31,10 +31,10 @@ class OgcApiResearchQueryDefault : OgcApiResearchQuery() {
 
     override lateinit var ogcParameter: OgcFilterParameter
 
-    override fun profileSpecificClauses(): MutableList<BoolFilter>? {
-        if (ogcParameter.qParameter != null) {
-            throw ConfigurationException.withReason("Request parameter 'q' is not yet supported for current profile. Please remove the parameter.")
-        }
-        return null
+    override fun checkParametersSupport() {
+        ogcParameter.qParameter?.let { throw ConfigurationException.withReason("Request parameter 'q' is not yet supported for current profile. Please remove the parameter.") }
+        ogcParameter.bbox?.let { throw ConfigurationException.withReason("Request parameter 'bbox' is not yet supported for current profile. Please remove the parameter.") }
     }
+
+    override fun profileSpecificClauses(): MutableList<BoolFilter>? = null
 }

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryFactory.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryFactory.kt
@@ -30,11 +30,14 @@ class OgcApiResearchQueryFactory(
 ) {
     fun getQuery(profile: CatalogProfile, ogcFilterParameter: OgcFilterParameter): ResearchQuery {
         try {
-            val filter = ogcApiSearchFilterList.filter { ogcApiSearchFilter: OgcApiResearchQuery -> ogcApiSearchFilter.profiles.contains(profile.identifier) }
+            var filter = ogcApiSearchFilterList.filter { ogcApiSearchFilter: OgcApiResearchQuery -> ogcApiSearchFilter.profiles.contains(profile.identifier) }
             if (filter.size > 1) throw ConfigurationException.withReason("Record query is not possible. The profile '$profile' has more than one OgcApiResearchQuery.")
+            if (filter.isEmpty()) {
+                filter = ogcApiSearchFilterList.filter { ogcApiSearchFilter: OgcApiResearchQuery -> ogcApiSearchFilter.profiles.contains("fallback") }
+            }
             return filter.first().createQuery(ogcFilterParameter)
         } catch (e: NoSuchElementException) {
-            throw ConfigurationException.withReason("Record query is not possible. The profile '$profile' does not have a OgcApiResearchQuery.")
+            throw ConfigurationException.withReason("OGC Record query is not possible. $e")
         }
     }
 }

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryFactory.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryFactory.kt
@@ -22,20 +22,18 @@ package de.ingrid.igeserver.features.ogc_api_records.services.research_query
 import de.ingrid.igeserver.configuration.ConfigurationException
 import de.ingrid.igeserver.model.ResearchQuery
 import de.ingrid.igeserver.services.CatalogProfile
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 
 @Service
 class OgcApiResearchQueryFactory(
     private val ogcApiSearchFilterList: List<OgcApiResearchQuery>,
-    @Qualifier("default") private val defaultFilter: OgcApiResearchQuery,
 ) {
     fun getQuery(profile: CatalogProfile, ogcFilterParameter: OgcFilterParameter): ResearchQuery {
         try {
             val filter = ogcApiSearchFilterList.filter { ogcApiSearchFilter: OgcApiResearchQuery -> ogcApiSearchFilter.profiles.contains(profile.identifier) }
             return when {
                 filter.size > 1 -> throw ConfigurationException.withReason("Record query is not possible. The profile '$profile' has more than one OgcApiResearchQuery.")
-                filter.isEmpty() -> defaultFilter.createQuery(ogcFilterParameter)
+                filter.isEmpty() -> OgcApiResearchQueryDefault().createQuery(ogcFilterParameter)
                 else -> filter.first().createQuery(ogcFilterParameter)
             }
         } catch (e: NoSuchElementException) {

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryFactory.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryFactory.kt
@@ -22,18 +22,20 @@ package de.ingrid.igeserver.features.ogc_api_records.services.research_query
 import de.ingrid.igeserver.configuration.ConfigurationException
 import de.ingrid.igeserver.model.ResearchQuery
 import de.ingrid.igeserver.services.CatalogProfile
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 
 @Service
 class OgcApiResearchQueryFactory(
     private val ogcApiSearchFilterList: List<OgcApiResearchQuery>,
+    @Qualifier("default") private val defaultFilter: OgcApiResearchQuery,
 ) {
     fun getQuery(profile: CatalogProfile, ogcFilterParameter: OgcFilterParameter): ResearchQuery {
         try {
             val filter = ogcApiSearchFilterList.filter { ogcApiSearchFilter: OgcApiResearchQuery -> ogcApiSearchFilter.profiles.contains(profile.identifier) }
             return when {
                 filter.size > 1 -> throw ConfigurationException.withReason("Record query is not possible. The profile '$profile' has more than one OgcApiResearchQuery.")
-                filter.isEmpty() -> OgcApiResearchQueryDefault().createQuery(ogcFilterParameter)
+                filter.isEmpty() -> defaultFilter.createQuery(ogcFilterParameter)
                 else -> filter.first().createQuery(ogcFilterParameter)
             }
         } catch (e: NoSuchElementException) {

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryFactory.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/research_query/OgcApiResearchQueryFactory.kt
@@ -22,22 +22,24 @@ package de.ingrid.igeserver.features.ogc_api_records.services.research_query
 import de.ingrid.igeserver.configuration.ConfigurationException
 import de.ingrid.igeserver.model.ResearchQuery
 import de.ingrid.igeserver.services.CatalogProfile
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 
 @Service
 class OgcApiResearchQueryFactory(
     private val ogcApiSearchFilterList: List<OgcApiResearchQuery>,
+    @Qualifier("default") private val defaultFilter: OgcApiResearchQuery,
 ) {
     fun getQuery(profile: CatalogProfile, ogcFilterParameter: OgcFilterParameter): ResearchQuery {
         try {
-            var filter = ogcApiSearchFilterList.filter { ogcApiSearchFilter: OgcApiResearchQuery -> ogcApiSearchFilter.profiles.contains(profile.identifier) }
-            if (filter.size > 1) throw ConfigurationException.withReason("Record query is not possible. The profile '$profile' has more than one OgcApiResearchQuery.")
-            if (filter.isEmpty()) {
-                filter = ogcApiSearchFilterList.filter { ogcApiSearchFilter: OgcApiResearchQuery -> ogcApiSearchFilter.profiles.contains("fallback") }
+            val filter = ogcApiSearchFilterList.filter { ogcApiSearchFilter: OgcApiResearchQuery -> ogcApiSearchFilter.profiles.contains(profile.identifier) }
+            return when {
+                filter.size > 1 -> throw ConfigurationException.withReason("Record query is not possible. The profile '$profile' has more than one OgcApiResearchQuery.")
+                filter.isEmpty() -> defaultFilter.createQuery(ogcFilterParameter)
+                else -> filter.first().createQuery(ogcFilterParameter)
             }
-            return filter.first().createQuery(ogcFilterParameter)
         } catch (e: NoSuchElementException) {
-            throw ConfigurationException.withReason("OGC Record query is not possible. $e")
+            throw ConfigurationException.withReason("OGC Record query failed due to an unexpected error in OgcApiResearchQuery. $e")
         }
     }
 }


### PR DESCRIPTION
Summary:
This PR introduces a fallback mechanism to ResearchQueryFactory, ensuring that the OGC API getRecords endpoint returns records by default when no profile-specific logic is available.

- If no customization is implemented for a profile, the factory now returns a default (empty) query instead of throwing an error.
- If the q parameter is present in the OGC getRecords request and no profile-specific logic exists, an error will still be thrown to highlight unsupported query functionality.
