### PR TITLE
feature/7740-dataOriginImportIdentifier

### DIFF
--- a/frontend/src/app/+importExport/import/import.component.html
+++ b/frontend/src/app/+importExport/import/import.component.html
@@ -7,6 +7,14 @@
             Unterstützt werden das interne Format als JSON, welches beim Export
             produziert wird, sowie das ISO 19139 Format.
         </p>
+
+        <p>
+            <b>Hinweis:</b>
+            Beim Import einer ISO zip-Datei können interne Verweise ggf. nicht
+            aufgelöst werden, wenn verlinkte Dokumente noch fehlen. Ein erneuter
+            Import der gleichen Datei kann die Referenzen nachträglich korrekt
+            herstellen.
+        </p>
     </div>
 
     <div main-header>

--- a/server/src/main/java/de/ingrid/igeserver/exports/internal/InternalExporter.kt
+++ b/server/src/main/java/de/ingrid/igeserver/exports/internal/InternalExporter.kt
@@ -76,7 +76,7 @@ class InternalExporter(
 
         return jacksonObjectMapper().createObjectNode().apply {
             put("_export_date", OffsetDateTime.now().toString())
-            put("_version", "1.3.0")
+            put("_version", "1.4.0")
             put("_profile", profile)
             set<ObjectNode>(
                 "resources",

--- a/server/src/main/java/de/ingrid/igeserver/exports/iso/Date.kt
+++ b/server/src/main/java/de/ingrid/igeserver/exports/iso/Date.kt
@@ -24,4 +24,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
 data class Date(
     @JacksonXmlProperty(localName = "Date") var date: String? = null,
     @JacksonXmlProperty(localName = "DateTime") var dateTime: String? = null,
-)
+) {
+    fun getBestDate(): String? = dateTime ?: date
+}

--- a/server/src/main/java/de/ingrid/igeserver/imports/internal/InternalImporter.kt
+++ b/server/src/main/java/de/ingrid/igeserver/imports/internal/InternalImporter.kt
@@ -30,6 +30,7 @@ import de.ingrid.igeserver.imports.internal.migrations.Migrate002
 import de.ingrid.igeserver.imports.internal.migrations.Migrate110
 import de.ingrid.igeserver.imports.internal.migrations.Migrate120
 import de.ingrid.igeserver.imports.internal.migrations.Migrate130
+import de.ingrid.igeserver.imports.internal.migrations.Migrate140
 import de.ingrid.igeserver.services.MapperService
 import de.ingrid.igeserver.utils.getString
 import org.springframework.http.MediaType
@@ -69,6 +70,10 @@ class InternalImporter : IgeImporter {
         if (version == "1.2.0" && profile.startsWith("ingrid")) {
             documents = Migrate130.migrate(documents)
             version = "1.3.0"
+        }
+        if (version == "1.3.0") {
+            documents = Migrate140.migrate(documents)
+            version = "1.4.0"
         }
 
         return jacksonObjectMapper().createArrayNode().apply {

--- a/server/src/main/java/de/ingrid/igeserver/imports/internal/migrations/Migrate140.kt
+++ b/server/src/main/java/de/ingrid/igeserver/imports/internal/migrations/Migrate140.kt
@@ -1,0 +1,53 @@
+/**
+ * ==================================================
+ * Copyright (C) 2023-2025 wemove digital solutions GmbH
+ * ==================================================
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be
+ * approved by the European Commission - subsequent versions of the
+ * EUPL (the "Licence");
+ *
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package de.ingrid.igeserver.imports.internal.migrations
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import de.ingrid.igeserver.utils.getString
+
+class Migrate140 {
+
+    companion object {
+        fun migrate(documents: JsonNode): JsonNode {
+            listOf("draft", "published").forEach { type ->
+                documents.get(type)?.let { docVersion ->
+                    docVersion as ObjectNode
+                    migrateReferences(docVersion)
+                }
+            }
+            return documents
+        }
+
+        private fun migrateReferences(doc: ObjectNode) {
+            val descriptions = doc.get("dataQualityInfo")?.get("lineage")?.get("source")?.get("descriptions")
+            if (descriptions == null || descriptions.isNull) return
+
+            descriptions.forEach {
+                if (it.getString("_type").isNullOrEmpty()) {
+                    (it as ObjectNode).apply {
+                        remove("key")
+                        put("_type", "freeDescription")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/server/src/main/java/de/ingrid/igeserver/imports/internal/migrations/Migrate140.kt
+++ b/server/src/main/java/de/ingrid/igeserver/imports/internal/migrations/Migrate140.kt
@@ -21,6 +21,7 @@ package de.ingrid.igeserver.imports.internal.migrations
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
+import de.ingrid.igeserver.utils.getPath
 import de.ingrid.igeserver.utils.getString
 
 class Migrate140 {
@@ -37,7 +38,7 @@ class Migrate140 {
         }
 
         private fun migrateReferences(doc: ObjectNode) {
-            val descriptions = doc.get("dataQualityInfo")?.get("lineage")?.get("source")?.get("descriptions")
+            val descriptions = doc.getPath("dataQualityInfo.lineage.source.descriptions")
             if (descriptions == null || descriptions.isNull) return
 
             descriptions.forEach {

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/exporter/GeodatasetModelTransformer.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/exporter/GeodatasetModelTransformer.kt
@@ -241,6 +241,7 @@ open class GeodatasetModelTransformer(transformerConfig: TransformerConfig) : In
         data.dataQualityInfo?.lineage?.source?.processStep?.description?.map { codelists.getValue("", it) }
             ?: emptyList()
 
+    // TODO: class LineageSourceDescription is defined 3 times! Refactor to use model from Importer?
     data class LineageSourceDescription(
         val value: String,
         val title: String?,

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeodatasetMapper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeodatasetMapper.kt
@@ -78,16 +78,11 @@ open class GeodatasetMapper(isoData: IsoImportData) : GeneralMapper(isoData) {
                 ?.map {
                     val identifier = it.liSource?.sourceCitation?.citation?.identifier?.getOrNull(0)?.mdIdentifier?.code?.value
 
-                    fun extractUUID(url: String?): String? {
-                        val regex = Regex("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
-                        return if (url is String) regex.find(url)?.value else null
-                    }
-
                     fun getGeoDatasetUuid(): String? {
-                        val uuidOfIdentifier = extractUUID(identifier)
+                        val idOfIdentifier = identifier?.substringAfterLast("/")
                         val response = isoData.researchService.query(
                             catalogId,
-                            ResearchQuery(null, BoolFilter("AND", listOf("document_wrapper.type = 'InGridGeoDataset'", "deleted = 0", "state = 'PUBLISHED'", "data ->> 'identifier' IN ('$identifier', '$uuidOfIdentifier')"), null, null, false)),
+                            ResearchQuery(null, BoolFilter("AND", listOf("document_wrapper.type = 'InGridGeoDataset'", "deleted = 0", "state = 'PUBLISHED'", "data ->> 'identifier' IN ('$identifier', '$idOfIdentifier')"), null, null, false)),
                         )
                         return if (response.totalHits == 1) response.hits[0].uuid else null
                     }

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeodatasetMapper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeodatasetMapper.kt
@@ -93,7 +93,7 @@ open class GeodatasetMapper(isoData: IsoImportData) : GeneralMapper(isoData) {
                     }
                     LineageSourceDescription(
                         value = it.liSource?.description?.value,
-                        date = it.liSource?.sourceCitation?.citation?.date?.getOrNull(0)?.date?.date?.dateTime,
+                        date = it.liSource?.sourceCitation?.citation?.date?.getOrNull(0)?.date?.date?.getBestDate(),
                         dateType = dateType,
                         title = if (internalGeoDatasetUuid == null) it.liSource?.sourceCitation?.citation?.title?.value else null,
                         identifier = if (internalGeoDatasetUuid == null) identifier else null,

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeodatasetMapper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeodatasetMapper.kt
@@ -87,7 +87,7 @@ open class GeodatasetMapper(isoData: IsoImportData) : GeneralMapper(isoData) {
                         val uuidOfIdentifier = extractUUID(identifier)
                         val response = isoData.researchService.query(
                             catalogId,
-                            ResearchQuery(null, BoolFilter("AND", listOf("document_wrapper.type = 'InGridGeoDataset'", "deleted = 0", "state = 'PUBLISHED'", "data ->> 'identifier' = '$uuidOfIdentifier'"), null, null, false)),
+                            ResearchQuery(null, BoolFilter("AND", listOf("document_wrapper.type = 'InGridGeoDataset'", "deleted = 0", "state = 'PUBLISHED'", "data ->> 'identifier' IN ('$identifier', '$uuidOfIdentifier')"), null, null, false)),
                         )
                         return if (response.totalHits == 1) response.hits[0].uuid else null
                     }

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeodatasetMapper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeodatasetMapper.kt
@@ -78,10 +78,16 @@ open class GeodatasetMapper(isoData: IsoImportData) : GeneralMapper(isoData) {
                 ?.map {
                     val identifier = it.liSource?.sourceCitation?.citation?.identifier?.getOrNull(0)?.mdIdentifier?.code?.value
 
+                    fun extractUUID(url: String?): String? {
+                        val regex = Regex("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
+                        return if (url is String) regex.find(url)?.value else null
+                    }
+
                     fun getGeoDatasetUuid(): String? {
+                        val uuidOfIdentifier = extractUUID(identifier)
                         val response = isoData.researchService.query(
                             catalogId,
-                            ResearchQuery(null, BoolFilter("AND", listOf("document_wrapper.type = 'InGridGeoDataset'", "deleted = 0", "state = 'PUBLISHED'", "data ->> 'identifier' = '$identifier'"), null, null, false)),
+                            ResearchQuery(null, BoolFilter("AND", listOf("document_wrapper.type = 'InGridGeoDataset'", "deleted = 0", "state = 'PUBLISHED'", "data ->> 'identifier' = '$uuidOfIdentifier'"), null, null, false)),
                         )
                         return if (response.totalHits == 1) response.hits[0].uuid else null
                     }
@@ -92,7 +98,7 @@ open class GeodatasetMapper(isoData: IsoImportData) : GeneralMapper(isoData) {
                     }
                     LineageSourceDescription(
                         value = it.liSource?.description?.value,
-                        date = it.liSource?.sourceCitation?.citation?.date?.getOrNull(0)?.date?.date?.date,
+                        date = it.liSource?.sourceCitation?.citation?.date?.getOrNull(0)?.date?.date?.dateTime,
                         dateType = dateType,
                         title = if (internalGeoDatasetUuid == null) it.liSource?.sourceCitation?.citation?.title?.value else null,
                         identifier = if (internalGeoDatasetUuid == null) identifier else null,

--- a/server/src/main/resources/ingrid/schemes/geo-dataset-base.schema.json
+++ b/server/src/main/resources/ingrid/schemes/geo-dataset-base.schema.json
@@ -133,16 +133,21 @@
         "descriptions": {
           "type": "array",
           "items": {
-            "_type": "string",
-            "uuidRef": ["null", "string"],
-            "url": ["null", "string"],
-            "identifier": ["null", "string"],
-            "date": {
-              "type": ["null", "string"],
-              "format": "date-time"
-            },
-            "dateType": {
-              "$ref": "../../general.schema.json#/definitions/KeyValue"
+            "type": "object",
+            "unevaluatedProperties": false,
+            "properties": {
+              "_type": "string",
+              "value": "string",
+              "uuidRef": ["null", "string"],
+              "url": ["null", "string"],
+              "identifier": ["null", "string"],
+              "date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "dateType": {
+                "$ref": "../../general.schema.json#/definitions/KeyValue"
+              }
             }
           }
         }

--- a/server/src/main/resources/ingrid/schemes/geo-dataset-base.schema.json
+++ b/server/src/main/resources/ingrid/schemes/geo-dataset-base.schema.json
@@ -136,11 +136,36 @@
             "type": "object",
             "unevaluatedProperties": false,
             "properties": {
-              "_type": "string",
-              "value": "string",
-              "uuidRef": ["null", "string"],
-              "url": ["null", "string"],
-              "identifier": ["null", "string"],
+              "_type": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              },
+              "uuidRef": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "url": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "identifier": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "title": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
               "date": {
                 "type": ["null", "string"],
                 "format": "date-time"

--- a/server/src/main/resources/templates/export/ingrid/idf/dataQuality.jte
+++ b/server/src/main/resources/templates/export/ingrid/idf/dataQuality.jte
@@ -255,11 +255,7 @@
                                     <gmd:date>
                                         <gmd:CI_Date>
                                             <gmd:date>
-                                                @if(description.getDate().contains("T"))
-                                                    <gco:DateTime>${description.getDate()}</gco:DateTime>
-                                                @else
-                                                    <gco:Date>${description.getDate()}</gco:Date>
-                                                @endif
+                                                <gco:Date>${description.getDate()}</gco:Date>
                                             </gmd:date>
                                             <gmd:dateType>
                                                 <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="${description.getDateType()}">${description.getDateType()}</gmd:CI_DateTypeCode>
@@ -272,9 +268,7 @@
                                                 <gco:CharacterString>${description.getIdentifier()}</gco:CharacterString>
                                             </gmd:code>
                                             @if(description.getUuidRef() != null)
-                                                <idf:uuid>
-                                                    ${description.getUuidRef()}
-                                                </idf:uuid>
+                                                <idf:uuid>${description.getUuidRef()}</idf:uuid>
                                             @endif
                                         </gmd:MD_Identifier>
                                     </gmd:identifier>

--- a/server/src/main/resources/templates/export/ingrid/idf/dataQuality.jte
+++ b/server/src/main/resources/templates/export/ingrid/idf/dataQuality.jte
@@ -267,6 +267,11 @@
                                             <gmd:code>
                                                 <gco:CharacterString>${description.getIdentifier()}</gco:CharacterString>
                                             </gmd:code>
+                                            @if(description.getUuidRef() != null)
+                                                <idf:uuid>
+                                                    ${description.getUuidRef()}
+                                                </idf:uuid>
+                                            @endif
                                         </gmd:MD_Identifier>
                                     </gmd:identifier>
                                 </gmd:CI_Citation>

--- a/server/src/main/resources/templates/export/ingrid/idf/dataQuality.jte
+++ b/server/src/main/resources/templates/export/ingrid/idf/dataQuality.jte
@@ -255,7 +255,11 @@
                                     <gmd:date>
                                         <gmd:CI_Date>
                                             <gmd:date>
-                                                <gco:DateTime>${description.getDate()}</gco:DateTime>
+                                                @if(description.getDate().contains("T"))
+                                                    <gco:DateTime>${description.getDate()}</gco:DateTime>
+                                                @else
+                                                    <gco:Date>${description.getDate()}</gco:Date>
+                                                @endif
                                             </gmd:date>
                                             <gmd:dateType>
                                                 <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="${description.getDateType()}">${description.getDateType()}</gmd:CI_DateTypeCode>

--- a/server/src/test/resources/export/ingrid/geo-dataset.maximal.json
+++ b/server/src/test/resources/export/ingrid/geo-dataset.maximal.json
@@ -101,7 +101,31 @@
             }
           ]
         },
-        "descriptions": [{ "key": null, "value": "data-basis" }]
+        "descriptions": [
+          {
+            "_type": "freeDescription",
+            "value": "Ein freier Beschreibungstext"
+          },
+          {
+            "_type": "freeDescription",
+            "value": "Beschreibungstext",
+            "identifier": "https://registry.gdi-de.org/id/ogctestcatalog/e8f0fcbb-3583-4848-9782-d2e89dcba887",
+            "title": "Titel von Referenz",
+            "date": "2024-09-02T22:00:00.000Z",
+            "dateType": {
+              "key": "2"
+            }
+          },
+          {
+            "_type": "internalDataOrigin",
+            "value": "Lokale interne Referenz",
+            "uuidRef": "4915275a-733a-47cd-b1a6-1a3f1e976948",
+            "date": "2025-02-26T23:00:00.000Z",
+            "dateType": {
+              "key": "3"
+            }
+          }
+        ]
       }
     }
   },

--- a/server/src/test/resources/ingrid/import/iso_geodataset_full-expected.json
+++ b/server/src/test/resources/ingrid/import/iso_geodataset_full-expected.json
@@ -394,6 +394,13 @@
               "dateType": { "key": "1" },
               "uuidRef": "00000000-0000-0000-0000-000000000000",
               "_type": "internalDataOrigin"
+            },
+            {
+              "value": "Beschreibung der Datengrundlage eines Geodatensatzes",
+              "date": "2024-11-18",
+              "dateType": { "key": "1" },
+              "uuidRef": "00000000-0000-0000-0000-000000000000",
+              "_type": "internalDataOrigin"
             }
           ],
           "processStep": {

--- a/server/src/test/resources/ingrid/import/iso_geodataset_full.xml
+++ b/server/src/test/resources/ingrid/import/iso_geodataset_full.xml
@@ -1376,6 +1376,37 @@
                             </gmd:sourceCitation>
                         </gmd:LI_Source>
                     </gmd:source>
+                    <gmd:source>
+                        <gmd:LI_Source>
+                            <gmd:description>
+                                <gco:CharacterString>Beschreibung der Datengrundlage eines Geodatensatzes</gco:CharacterString>
+                            </gmd:description>
+                            <gmd:sourceCitation>
+                                <gmd:CI_Citation>
+                                    <gmd:title>
+                                        <gco:CharacterString>Titel von Geodatensatz mit Datum</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date>
+                                        <gmd:CI_Date>
+                                            <gmd:date>
+                                                <gco:Date>2024-11-18</gco:Date>
+                                            </gmd:date>
+                                            <gmd:dateType>
+                                                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                            </gmd:dateType>
+                                        </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:identifier>
+                                        <gmd:MD_Identifier>
+                                            <gmd:code>
+                                                <gco:CharacterString>https://registry.gdi-de.org/id/ogctestcatalog/e8f0fcbb-3583-4848-9782-d2e89dcba887</gco:CharacterString>
+                                            </gmd:code>
+                                        </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                </gmd:CI_Citation>
+                            </gmd:sourceCitation>
+                        </gmd:LI_Source>
+                    </gmd:source>
                 </gmd:LI_Lineage>
             </gmd:lineage>
         </gmd:DQ_DataQuality>

--- a/server/src/test/resources/ingrid/import/iso_geodataset_full.xml
+++ b/server/src/test/resources/ingrid/import/iso_geodataset_full.xml
@@ -1358,7 +1358,7 @@
                                     <gmd:date>
                                         <gmd:CI_Date>
                                             <gmd:date>
-                                                <gco:Date>2024-11-18T23:00:00.000Z</gco:Date>
+                                                <gco:DateTime>2024-11-18T23:00:00.000Z</gco:DateTime>
                                             </gmd:date>
                                             <gmd:dateType>
                                                 <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>


### PR DESCRIPTION
Ticket zum dem Bug:
https://redmine.informationgrid.eu/issues/7740?next_issue_id=7739

Umgesetzt wurde:
- Import migration task
- Update Hinweis für ISO zip-Datei Import
- Verlinkung von internen Geodatensetzen unter Datengrundlage/Herkunft korrekt auflösen
- Strengere Schema Validierung

Frage: 
Ist das Migrationsscript Migrate130 korrekt ausgefüht? 

```
        if (version == "1.3.0") {
            documents = Migrate140.migrate(documents)
            version = "1.4.0"
        }
```
