### PR TITLE
Add API distribution support for fileReferences to InGrid profile

### DIFF
--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_distributions/distribution_helper/OgcDistributionHelper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_distributions/distribution_helper/OgcDistributionHelper.kt
@@ -20,6 +20,8 @@
 package de.ingrid.igeserver.features.ogc_api_distributions.distribution_helper
 
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import de.ingrid.igeserver.persistence.postgresql.jpa.model.ige.Document
 
 interface OgcDistributionHelper {
@@ -54,4 +56,6 @@ interface OgcDistributionHelper {
      * @return true if distribution can be handled, otherwise false
      */
     fun canHandleDistribution(profile: String): Boolean
+
+    fun convertListToJsonNode(listOfJsonNodes: List<Any>): ArrayNode = jacksonObjectMapper().valueToTree(listOfJsonNodes)
 }

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_distributions/profiles/bmi/distribution_helper/BmiDistributionHelper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_distributions/profiles/bmi/distribution_helper/BmiDistributionHelper.kt
@@ -19,23 +19,15 @@
  */
 package de.ingrid.igeserver.features.ogc_api_distributions.profiles.bmi.distribution_helper
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import de.ingrid.igeserver.features.ogc_api_distributions.distribution_helper.DistributionTypeInfo
-import de.ingrid.igeserver.features.ogc_api_distributions.distribution_helper.OgcDistributionHelper
-import de.ingrid.igeserver.persistence.postgresql.jpa.model.ige.Document
-import de.ingrid.igeserver.utils.getBoolean
-import de.ingrid.igeserver.utils.getString
-import de.ingrid.igeserver.utils.ifFalse
+import de.ingrid.igeserver.features.ogc_api_distributions.profiles.opendata.distribution_helper.OpenDataDistributionHelper
 import de.ingrid.mdek.upload.storage.Storage
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
 
 @Profile("bmi")
 @Service
-class BmiDistributionHelper(
-    private val storage: Storage,
-) : OgcDistributionHelper {
+class BmiDistributionHelper(storage: Storage) : OpenDataDistributionHelper(storage) {
 
     override val typeInfo: DistributionTypeInfo
         get() = DistributionTypeInfo(
@@ -46,37 +38,4 @@ class BmiDistributionHelper(
         )
 
     override fun canHandleDistribution(profile: String): Boolean = "bmi" == profile
-
-    override fun getDistributionDetails(document: Document, collectionId: String, recordId: String, distributionId: String?): JsonNode {
-        val allDistributions = document.data["distributions"]
-
-        return if (distributionId.isNullOrEmpty()) {
-            allDistributions
-        } else {
-            val filteredDistributions = allDistributions.filter { it.getString("link.uri") == distributionId }
-            convertListToJsonNode(filteredDistributions)
-        }
-    }
-
-    override fun searchForMissingFiles(
-        distributions: JsonNode,
-        collectionId: String,
-        userID: String,
-        recordId: String,
-        distributionId: String?,
-    ): List<String> {
-        val missingFiles: MutableList<String> = mutableListOf()
-
-        distributions.forEach { distribution ->
-            val currentDistributionId = distribution.getString("link.uri")!!
-            val isLink = distribution.getBoolean("link.asLink")!!
-            isLink.ifFalse {
-                val distributionExists = storage.exists(collectionId, userID, recordId, currentDistributionId)
-                distributionExists.ifFalse { missingFiles.add(currentDistributionId) }
-            }
-        }
-        return missingFiles
-    }
-
-    private fun convertListToJsonNode(listOfJsonNodes: List<Any>): JsonNode = jacksonObjectMapper().valueToTree(listOfJsonNodes)
 }

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_distributions/profiles/ingrid/distribution_helper/IngridDistributionHelper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_distributions/profiles/ingrid/distribution_helper/IngridDistributionHelper.kt
@@ -20,6 +20,7 @@
 package de.ingrid.igeserver.features.ogc_api_distributions.profiles.ingrid.distribution_helper
 
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import de.ingrid.igeserver.features.ogc_api_distributions.distribution_helper.DistributionTypeInfo
 import de.ingrid.igeserver.features.ogc_api_distributions.distribution_helper.OgcDistributionHelper
@@ -37,6 +38,8 @@ class IngridDistributionHelper(
     private val storage: Storage,
 ) : OgcDistributionHelper {
 
+    private val mapper = jacksonObjectMapper()
+
     override val typeInfo: DistributionTypeInfo
         get() = DistributionTypeInfo(
             "ingrid",
@@ -48,14 +51,31 @@ class IngridDistributionHelper(
     override fun canHandleDistribution(profile: String): Boolean = "ingrid" == profile
 
     override fun getDistributionDetails(document: Document, collectionId: String, recordId: String, distributionId: String?): JsonNode {
-        val allDistributions = document.data["graphicOverviews"]
+        val graphicOverviews = document.data["graphicOverviews"] ?: mapper.createArrayNode()
+        val fileReferences = document.data["fileReferences"] ?: mapper.createArrayNode()
 
-        return if (distributionId.isNullOrEmpty()) {
-            allDistributions
-        } else {
-            val filteredDistributions = allDistributions.filter { it.getString("fileName.uri") == distributionId }
-            convertListToJsonNode(filteredDistributions)
+        val filteredGraphicOverviews = when {
+            distributionId.isNullOrEmpty() -> graphicOverviews
+            else -> convertListToJsonNode(
+                graphicOverviews.filter {
+                    it.getBoolean("fileName.asLink") == false && it.getString("fileName.uri") == distributionId
+                },
+            )
         }
+
+        val filteredFileReferences = when {
+            distributionId.isNullOrEmpty() -> fileReferences
+            else -> convertListToJsonNode(
+                fileReferences.filter {
+                    it.getBoolean("link.asLink") == false && it.getString("link.uri") == distributionId
+                },
+            )
+        }
+
+        val resultArray = mapper.createArrayNode()
+        resultArray.addAll(filteredGraphicOverviews as ArrayNode)
+        resultArray.addAll(filteredFileReferences as ArrayNode)
+        return resultArray
     }
 
     override fun searchForMissingFiles(

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_distributions/profiles/ingrid/distribution_helper/IngridDistributionHelper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_distributions/profiles/ingrid/distribution_helper/IngridDistributionHelper.kt
@@ -50,20 +50,22 @@ class IngridDistributionHelper(
 
     override fun canHandleDistribution(profile: String): Boolean = "ingrid" == profile
 
-    override fun getDistributionDetails(document: Document, collectionId: String, recordId: String, distributionId: String?): JsonNode {
-        val graphicOverviews = document.data["graphicOverviews"] ?: mapper.createArrayNode()
-        val fileReferences = document.data["fileReferences"] ?: mapper.createArrayNode()
+    override fun getDistributionDetails(
+        document: Document,
+        collectionId: String,
+        recordId: String,
+        distributionId: String?,
+    ): JsonNode = mapper.createArrayNode().let {
+        it.addAll(this.getFilteredGraphicOverviews(document, distributionId))
+        it.addAll(this.getFilteredFileReferences(document, distributionId))
+    }
 
-        val filteredGraphicOverviews = when {
-            distributionId.isNullOrEmpty() -> graphicOverviews
-            else -> convertListToJsonNode(
-                graphicOverviews.filter {
-                    it.getBoolean("fileName.asLink") == false && it.getString("fileName.uri") == distributionId
-                },
-            )
-        }
-
-        val filteredFileReferences = when {
+    private fun getFilteredFileReferences(
+        document: Document,
+        distributionId: String?,
+    ): ArrayNode {
+        val fileReferences = document.data["fileReferences"] as ArrayNode? ?: mapper.createArrayNode()
+        return when {
             distributionId.isNullOrEmpty() -> fileReferences
             else -> convertListToJsonNode(
                 fileReferences.filter {
@@ -71,11 +73,21 @@ class IngridDistributionHelper(
                 },
             )
         }
+    }
 
-        val resultArray = mapper.createArrayNode()
-        resultArray.addAll(filteredGraphicOverviews as ArrayNode)
-        resultArray.addAll(filteredFileReferences as ArrayNode)
-        return resultArray
+    private fun getFilteredGraphicOverviews(
+        document: Document,
+        distributionId: String?,
+    ): ArrayNode {
+        val graphicOverviews = document.data["graphicOverviews"] as ArrayNode? ?: mapper.createArrayNode()
+        return when {
+            distributionId.isNullOrEmpty() -> graphicOverviews
+            else -> convertListToJsonNode(
+                graphicOverviews.filter {
+                    it.getBoolean("fileName.asLink") == false && it.getString("fileName.uri") == distributionId
+                },
+            )
+        }
     }
 
     override fun searchForMissingFiles(
@@ -98,6 +110,4 @@ class IngridDistributionHelper(
 
         return missingFiles
     }
-
-    private fun convertListToJsonNode(listOfJsonNodes: List<Any>): JsonNode = jacksonObjectMapper().valueToTree(listOfJsonNodes)
 }

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_distributions/profiles/opendata/distribution_helper/OpenDataDistributionHelper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_distributions/profiles/opendata/distribution_helper/OpenDataDistributionHelper.kt
@@ -20,7 +20,6 @@
 package de.ingrid.igeserver.features.ogc_api_distributions.profiles.opendata.distribution_helper
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import de.ingrid.igeserver.features.ogc_api_distributions.distribution_helper.DistributionTypeInfo
 import de.ingrid.igeserver.features.ogc_api_distributions.distribution_helper.OgcDistributionHelper
 import de.ingrid.igeserver.persistence.postgresql.jpa.model.ige.Document
@@ -77,6 +76,4 @@ class OpenDataDistributionHelper(
         }
         return missingFiles
     }
-
-    private fun convertListToJsonNode(listOfJsonNodes: List<Any>): JsonNode = jacksonObjectMapper().valueToTree(listOfJsonNodes)
 }

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_distributions/profiles/uvp/distribution_helper/UvpDistributionHelper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_distributions/profiles/uvp/distribution_helper/UvpDistributionHelper.kt
@@ -21,7 +21,6 @@ package de.ingrid.igeserver.features.ogc_api_distributions.profiles.uvp.distribu
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import de.ingrid.igeserver.features.ogc_api_distributions.distribution_helper.DistributionTypeInfo
 import de.ingrid.igeserver.features.ogc_api_distributions.distribution_helper.OgcDistributionHelper
 import de.ingrid.igeserver.persistence.postgresql.jpa.model.ige.Document
@@ -277,6 +276,4 @@ class UvpDistributionHelper(
         (processStep as ObjectNode).replace(docType, jsonNode)
         return processStep
     }
-
-    private fun convertListToJsonNode(listOfJsonNodes: List<Any>): JsonNode = jacksonObjectMapper().valueToTree(listOfJsonNodes)
 }


### PR DESCRIPTION
InGrid profile was missing support to handle distribution uploads to field "fileReferences". It only handled "graphicOverviews". Now it supports both.