### PR TITLE
feature/7548-filter-wwa

### DIFF
--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/LfuBayernProfile.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/LfuBayernProfile.kt
@@ -56,6 +56,8 @@ class LfuBayernProfile(
 
     override val indexExportFormatID = "indexInGridIDFLfuBayern"
 
+    override fun getElasticsearchMapping(format: String): String = {}.javaClass.getResource("/ingrid/mappings/lfubayern/default-mapping.json")?.readText() ?: ""
+
     init {
         isoImport.profileMapper[ID] = isoImportLfUBayern
     }

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/exporter/CommonTransformations.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/exporter/CommonTransformations.kt
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import de.ingrid.igeserver.exporter.CodelistTransformer
 import de.ingrid.igeserver.exporter.model.CharacterStringModel
 import de.ingrid.igeserver.model.KeyValue
+import de.ingrid.igeserver.persistence.postgresql.jpa.model.ige.Document
 import de.ingrid.igeserver.profiles.ingrid.exporter.IngridModelTransformer.UseConstraintTemplate
 import de.ingrid.igeserver.profiles.ingrid.exporter.model.KeywordIso
 import de.ingrid.igeserver.profiles.ingrid.exporter.model.Thesaurus
@@ -32,6 +33,7 @@ import de.ingrid.igeserver.profiles.ingrid_lfubayern.exporter.external.Informati
 import de.ingrid.igeserver.profiles.ingrid_lfubayern.exporter.internal.GeodatasetTransformerLfub
 import de.ingrid.igeserver.profiles.ingrid_lfubayern.exporter.internal.GeoserviceTransformerLfub
 import de.ingrid.igeserver.profiles.ingrid_lfubayern.exporter.internal.InformationSystemTransformerLfub
+import de.ingrid.igeserver.services.DocumentService
 import de.ingrid.igeserver.utils.getString
 import de.ingrid.igeserver.utils.prefixIfNot
 import kotlin.reflect.KClass
@@ -98,6 +100,18 @@ fun lfubGetDescriptiveKeywords(
         superDescriptiveKeywords + lfugeoKeywords
     } else {
         superDescriptiveKeywords + lfuInternalKeywords + lfugeoKeywords
+    }
+}
+
+fun lfubGetTreePathNames(
+    documentService: DocumentService,
+    catalogIdentifier: String,
+    doc: Document,
+): List<String> {
+    val wrapper = documentService.getWrapperByCatalogAndDocumentUuid(catalogIdentifier, doc.uuid)
+    return wrapper.path.map {
+        val pathDoc = documentService.getDocumentByWrapperId(catalogIdentifier, it)
+        pathDoc.title ?: "???"
     }
 }
 

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/exporter/IngridExporterLfub.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/exporter/IngridExporterLfub.kt
@@ -29,6 +29,7 @@ import de.ingrid.igeserver.profiles.ingrid.exporter.IngridLuceneExporter
 import de.ingrid.igeserver.profiles.ingrid.exporter.TransformerCache
 import de.ingrid.igeserver.profiles.ingrid.exporter.TransformerConfig
 import de.ingrid.igeserver.profiles.ingrid.exporter.TransformerData
+import de.ingrid.igeserver.profiles.ingrid.exporter.convertStringToDocument
 import de.ingrid.igeserver.profiles.ingrid.exporter.model.IngridModel
 import de.ingrid.igeserver.profiles.ingrid.getISOFromElasticDocumentString
 import de.ingrid.igeserver.repository.DocumentWrapperRepository
@@ -37,6 +38,11 @@ import de.ingrid.igeserver.services.CodelistHandler
 import de.ingrid.igeserver.services.DocumentCategory
 import de.ingrid.igeserver.services.DocumentService
 import de.ingrid.mdek.upload.UploadConfig
+import de.ingrid.utils.xml.ConfigurableNamespaceContext
+import de.ingrid.utils.xml.IDFNamespaceContext
+import de.ingrid.utils.xml.IgcProfileNamespaceContext
+import de.ingrid.utils.xml.XMLUtils
+import de.ingrid.utils.xpath.XPathUtils
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 import kotlin.reflect.KClass
@@ -69,7 +75,39 @@ class IngridIdfExporterLfub(
     catalogService: CatalogService,
     @Lazy documentService: DocumentService,
 ) : IngridIDFExporter(codelistHandler, uploadConfig, catalogService, documentService) {
+
+    private var xpathUtils: XPathUtils
+
+    init {
+        val cnc = ConfigurableNamespaceContext()
+        cnc.addNamespaceContext(IDFNamespaceContext())
+        cnc.addNamespaceContext(IgcProfileNamespaceContext())
+
+        xpathUtils = XPathUtils(cnc)
+    }
+
     override fun getModelTransformerClass(docType: String): KClass<out Any>? = getLfuBayernTransformer(docType) ?: super.getModelTransformerClass(docType)
+
+    override fun run(doc: Document, catalogId: String, options: ExportOptions): String {
+        if (doc.type == "FOLDER") return ""
+
+        val idf = super.run(doc, catalogId, options)
+        val idfDoc = convertStringToDocument(idf)
+        val treePath = lfubGetTreePathNames(documentService, catalogId, doc)
+        addPathInfoToMdIdf(idfDoc!!, treePath.joinToString(","))
+        return XMLUtils.toString(idfDoc)
+    }
+
+    private fun addPathInfoToMdIdf(idf: org.w3c.dom.Document, treePath: String) {
+        val idfMdMetadataNode = xpathUtils.getNode(idf, "/idf:html/idf:body/idf:idfMdMetadata")
+        if (idfMdMetadataNode != null) {
+            val treePathNode = xpathUtils.createElementFromXPath(idfMdMetadataNode, "idf:treePath")
+            XMLUtils.createOrReplaceTextNode(
+                xpathUtils.createElementFromXPath(treePathNode, "gco:CharacterString"),
+                treePath,
+            )
+        }
+    }
 }
 
 @Service

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/exporter/IngridExporterLfub.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/exporter/IngridExporterLfub.kt
@@ -21,6 +21,7 @@ package de.ingrid.igeserver.profiles.ingrid_lfubayern.exporter
 
 import de.ingrid.igeserver.exports.ExportOptions
 import de.ingrid.igeserver.exports.ExportTypeInfo
+import de.ingrid.igeserver.persistence.postgresql.jpa.model.ige.Catalog
 import de.ingrid.igeserver.persistence.postgresql.jpa.model.ige.Document
 import de.ingrid.igeserver.profiles.ingrid.exporter.IngridIDFExporter
 import de.ingrid.igeserver.profiles.ingrid.exporter.IngridIndexExporter
@@ -68,7 +69,6 @@ class IngridIdfExporterLfub(
     catalogService: CatalogService,
     @Lazy documentService: DocumentService,
 ) : IngridIDFExporter(codelistHandler, uploadConfig, catalogService, documentService) {
-
     override fun getModelTransformerClass(docType: String): KClass<out Any>? = getLfuBayernTransformer(docType) ?: super.getModelTransformerClass(docType)
 }
 
@@ -84,6 +84,18 @@ class IngridLuceneExporterLfub(
     catalogService,
     documentService,
 ) {
+
+    override fun getTemplateForDoctype(doc: Document, catalog: Catalog, options: ExportOptions): Pair<String, Map<String, Any>> = when (doc.type) {
+        "InGridGeoDataset",
+        "InGridGeoService",
+        "InGridInformationSystem",
+        -> Pair(
+            "export/ingrid-lfubayern/lucene/template-lucene-lfubayern.jte",
+            getMapper(IngridDocType.DOCUMENT, doc, catalog, options),
+        )
+
+        else -> super.getTemplateForDoctype(doc, catalog, options)
+    }
 
     override fun getTransformer(data: TransformerData): Any = when (data.type) {
         IngridDocType.DOCUMENT -> {

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/exporter/internal/GeodatasetTransformerLfub.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/exporter/internal/GeodatasetTransformerLfub.kt
@@ -23,10 +23,13 @@ import de.ingrid.igeserver.profiles.ingrid.exporter.GeodatasetModelTransformer
 import de.ingrid.igeserver.profiles.ingrid.exporter.TransformerConfig
 import de.ingrid.igeserver.profiles.ingrid.exporter.model.Thesaurus
 import de.ingrid.igeserver.profiles.ingrid_lfubayern.exporter.lfubGetDescriptiveKeywords
+import de.ingrid.igeserver.profiles.ingrid_lfubayern.exporter.lfubGetTreePathNames
 import de.ingrid.igeserver.profiles.ingrid_lfubayern.exporter.lfubUseConstraints
 import de.ingrid.igeserver.utils.getString
 
-class GeodatasetTransformerLfub(transformerConfig: TransformerConfig) : GeodatasetModelTransformer(transformerConfig) {
+class GeodatasetTransformerLfub(transformerConfig: TransformerConfig) :
+    GeodatasetModelTransformer(transformerConfig),
+    IngridModelTransformerLfub {
 
     private val docData = doc.data
 
@@ -40,4 +43,6 @@ class GeodatasetTransformerLfub(transformerConfig: TransformerConfig) : Geodatas
     override fun getDescriptiveKeywords(): List<Thesaurus> = lfubGetDescriptiveKeywords(super.getDescriptiveKeywords(), docData, codelists)
 
     override val useConstraints: List<UseConstraintTemplate> = lfubUseConstraints(super.useConstraints, docData)
+
+    override val treePathNames: List<String> = lfubGetTreePathNames(documentService, catalogIdentifier, doc)
 }

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/exporter/internal/GeoserviceTransformerLfub.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/exporter/internal/GeoserviceTransformerLfub.kt
@@ -23,10 +23,13 @@ import de.ingrid.igeserver.profiles.ingrid.exporter.GeodataserviceModelTransform
 import de.ingrid.igeserver.profiles.ingrid.exporter.TransformerConfig
 import de.ingrid.igeserver.profiles.ingrid.exporter.model.Thesaurus
 import de.ingrid.igeserver.profiles.ingrid_lfubayern.exporter.lfubGetDescriptiveKeywords
+import de.ingrid.igeserver.profiles.ingrid_lfubayern.exporter.lfubGetTreePathNames
 import de.ingrid.igeserver.profiles.ingrid_lfubayern.exporter.lfubUseConstraints
 import de.ingrid.igeserver.utils.getString
 
-class GeoserviceTransformerLfub(transformerConfig: TransformerConfig) : GeodataserviceModelTransformer(transformerConfig) {
+class GeoserviceTransformerLfub(transformerConfig: TransformerConfig) :
+    GeodataserviceModelTransformer(transformerConfig),
+    IngridModelTransformerLfub {
 
     private val docData = doc.data
 
@@ -39,4 +42,6 @@ class GeoserviceTransformerLfub(transformerConfig: TransformerConfig) : Geodatas
     override fun getDescriptiveKeywords(): List<Thesaurus> = lfubGetDescriptiveKeywords(super.getDescriptiveKeywords(), docData, codelists)
 
     override val useConstraints: List<UseConstraintTemplate> = lfubUseConstraints(super.useConstraints, docData)
+
+    override val treePathNames: List<String> = lfubGetTreePathNames(documentService, catalogIdentifier, doc)
 }

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/exporter/internal/InformationSystemTransformerLfub.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/exporter/internal/InformationSystemTransformerLfub.kt
@@ -21,10 +21,13 @@ package de.ingrid.igeserver.profiles.ingrid_lfubayern.exporter.internal
 
 import de.ingrid.igeserver.profiles.ingrid.exporter.InformationSystemModelTransformer
 import de.ingrid.igeserver.profiles.ingrid.exporter.TransformerConfig
+import de.ingrid.igeserver.profiles.ingrid_lfubayern.exporter.lfubGetTreePathNames
 import de.ingrid.igeserver.profiles.ingrid_lfubayern.exporter.lfubUseConstraints
 import de.ingrid.igeserver.utils.getString
 
-class InformationSystemTransformerLfub(transformerConfig: TransformerConfig) : InformationSystemModelTransformer(transformerConfig) {
+class InformationSystemTransformerLfub(transformerConfig: TransformerConfig) :
+    InformationSystemModelTransformer(transformerConfig),
+    IngridModelTransformerLfub {
 
     private val docData = doc.data
 
@@ -35,4 +38,6 @@ class InformationSystemTransformerLfub(transformerConfig: TransformerConfig) : I
     override val datasetUri = docData.getString("dataSetURI")
 
     override val useConstraints: List<UseConstraintTemplate> = lfubUseConstraints(super.useConstraints, docData)
+
+    override val treePathNames: List<String> = lfubGetTreePathNames(documentService, catalogIdentifier, doc)
 }

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/exporter/internal/IngridModelTransformerLfub.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid_lfubayern/exporter/internal/IngridModelTransformerLfub.kt
@@ -1,0 +1,24 @@
+/**
+ * ==================================================
+ * Copyright (C) 2025 wemove digital solutions GmbH
+ * ==================================================
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be
+ * approved by the European Commission - subsequent versions of the
+ * EUPL (the "Licence");
+ *
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package de.ingrid.igeserver.profiles.ingrid_lfubayern.exporter.internal
+
+interface IngridModelTransformerLfub {
+    val treePathNames: List<String>
+}

--- a/server/src/main/resources/ingrid/mappings/lfubayern/default-mapping.json
+++ b/server/src/main/resources/ingrid/mappings/lfubayern/default-mapping.json
@@ -1,0 +1,417 @@
+{
+  "_source": {
+    "enabled": true
+  },
+  "properties": {
+    "iPlugId": {
+      "type": "keyword",
+      "store": true
+    },
+    "partner": {
+      "type": "keyword",
+      "store": true
+    },
+    "provider": {
+      "type": "keyword",
+      "store": true
+    },
+    "datatype": {
+      "type": "keyword",
+      "store": true
+    },
+    "dataSourceName": {
+      "type": "keyword",
+      "store": true
+    },
+    "object_node.tree_path.name": {
+      "type": "keyword",
+      "store": true
+    },
+    "kml": {
+      "type": "keyword",
+      "store": true
+    },
+    "additional_html_1": {
+      "type": "keyword",
+      "store": true
+    },
+    "capabilities_url": {
+      "type": "keyword",
+      "store": true
+    },
+    "capabilities_url_with_client": {
+      "type": "keyword",
+      "store": true
+    },
+    "refering_service_uuid": {
+      "type": "keyword",
+      "store": true
+    },
+    "t01_object.mod_time": {
+      "type": "keyword",
+      "store": true
+    },
+    "t01_object.metadata_time": {
+      "type": "keyword",
+      "store": true
+    },
+    "t01_object.obj_id": {
+      "type": "keyword",
+      "store": true
+    },
+    "t01_object.obj_class": {
+      "type": "keyword",
+      "store": true
+    },
+    "t01_object.org_obj_id": {
+      "type": "keyword",
+      "store": true
+    },
+    "t011_obj_serv.has_access_constraint": {
+      "type": "keyword",
+      "store": true
+    },
+    "t011_obj_serv.type": {
+      "type": "text",
+      "store": true
+    },
+    "t011_obj_serv.type_key": {
+      "type": "keyword",
+      "store": true
+    },
+    "t012_obj_adr.adr_id": {
+      "type": "keyword"
+    },
+    "t011_obj_serv_version.version_value": {
+      "type": "text",
+      "store": true
+    },
+    "t01_object.mod_uuid": {
+      "type": "keyword"
+    },
+    "t01_object.responsible_uuid": {
+      "type": "keyword"
+    },
+    "t011_obj_geo.datasource_uuid": {
+      "type": "keyword"
+    },
+    "t022_adr_adr.adr_to_id": {
+      "type": "keyword"
+    },
+    "object_reference.obj_to_uuid": {
+      "type": "keyword"
+    },
+    "object_reference.obj_uuid": {
+      "type": "keyword",
+      "store": true
+    },
+    "object_reference.obj_name": {
+      "type": "keyword",
+      "store": true
+    },
+    "object_reference.obj_class": {
+      "type": "keyword",
+      "store": true
+    },
+    "object_reference.type": {
+      "type": "keyword",
+      "store": true
+    },
+    "object_reference.version": {
+      "type": "keyword",
+      "store": true
+    },
+    "refering.object_reference.obj_uuid": {
+      "type": "keyword",
+      "store": true
+    },
+    "refering.object_reference.obj_name": {
+      "type": "keyword",
+      "store": true
+    },
+    "refering.object_reference.obj_class": {
+      "type": "keyword",
+      "store": true
+    },
+    "refering.object_reference.type": {
+      "type": "keyword",
+      "store": true
+    },
+    "refering.object_reference.version": {
+      "type": "keyword",
+      "store": true
+    },
+    "t02_address.adr_id": {
+      "type": "keyword",
+      "store": true
+    },
+    "t02_address.typ": {
+      "type": "keyword",
+      "store": true
+    },
+    "t02_address2.adr_id": {
+      "type": "keyword",
+      "store": true
+    },
+    "t02_address2.typ": {
+      "type": "keyword",
+      "store": true
+    },
+    "t02_address3.adr_id": {
+      "type": "keyword",
+      "store": true
+    },
+    "t02_address3.typ": {
+      "type": "keyword",
+      "store": true
+    },
+    "t02_address4.adr_id": {
+      "type": "keyword"
+    },
+    "t02_address5.adr_id": {
+      "type": "keyword"
+    },
+    "t02_address.org_adr_id": {
+      "type": "keyword"
+    },
+    "t02_address.mod_uuid": {
+      "type": "keyword"
+    },
+    "t02_address.mod_time": {
+      "type": "keyword",
+      "store": true
+    },
+    "t02_address.responsible_uuid": {
+      "type": "keyword",
+      "store": true
+    },
+    "t02_address.firstname": {
+      "type": "keyword",
+      "store": true
+    },
+    "t02_address.lastname": {
+      "type": "keyword",
+      "store": true
+    },
+    "t02_address.title": {
+      "type": "keyword",
+      "store": true
+    },
+    "t02_address.address": {
+      "type": "keyword",
+      "store": true
+    },
+    "t022_adr_adr.adr_from_id": {
+      "type": "keyword",
+      "store": true
+    },
+    "t022_adr_adr3.adr_from_id": {
+      "type": "keyword",
+      "store": true
+    },
+    "t011_obj_serv_op_connpoint.connect_point": {
+      "type": "keyword",
+      "store": true
+    },
+    "t03_catalogue.cat_uuid": {
+      "type": "keyword"
+    },
+    "t03_catalogue.mod_uuid": {
+      "type": "keyword"
+    },
+    "parent.object_node.obj_uuid": {
+      "type": "keyword"
+    },
+    "children.object_node.obj_uuid": {
+      "type": "keyword"
+    },
+    "parent.address_node.addr_uuid": {
+      "type": "keyword"
+    },
+    "parent2.address_node.addr_uuid": {
+      "type": "keyword"
+    },
+    "parent3.address_node.addr_uuid": {
+      "type": "keyword"
+    },
+    "parent4.address_node.addr_uuid": {
+      "type": "keyword"
+    },
+    "parent5.address_node.addr_uuid": {
+      "type": "keyword"
+    },
+    "children.address_node.addr_uuid": {
+      "type": "keyword"
+    },
+    "boost": {
+      "type": "float",
+      "store": true,
+      "null_value": 0.0
+    },
+    "title": {
+      "type": "text",
+      "analyzer": "german",
+      "store": true,
+      "fields": {
+        "ngram": {
+          "type": "text",
+          "analyzer": "ngram",
+          "search_analyzer": "german"
+        },
+        "edge_ngram": {
+          "type": "text",
+          "analyzer": "edge_ngram",
+          "search_analyzer": "german"
+        }
+      }
+    },
+    "title2": {
+      "type": "text",
+      "store": true
+    },
+    "title3": {
+      "type": "text",
+      "store": true
+    },
+    "summary": {
+      "type": "text",
+      "analyzer": "german",
+      "store": true,
+      "fields": {
+        "ngram": {
+          "type": "text",
+          "analyzer": "ngram",
+          "search_analyzer": "german"
+        },
+        "edge_ngram": {
+          "type": "text",
+          "analyzer": "edge_ngram",
+          "search_analyzer": "german"
+        }
+      }
+    },
+    "content": {
+      "type": "text",
+      "analyzer": "german",
+      "store": true,
+      "fields": {
+        "ngram": {
+          "type": "text",
+          "analyzer": "ngram",
+          "search_analyzer": "german"
+        },
+        "edge_ngram": {
+          "type": "text",
+          "analyzer": "edge_ngram",
+          "search_analyzer": "german"
+        }
+      }
+    },
+    "location": {
+      "type": "keyword",
+      "store": true
+    },
+    "x1": {
+      "type": "double",
+      "store": true
+    },
+    "x2": {
+      "type": "double",
+      "store": true
+    },
+    "y1": {
+      "type": "double",
+      "store": true
+    },
+    "y2": {
+      "type": "double",
+      "store": true
+    },
+    "idf": {
+      "type": "text",
+      "store": true
+    },
+    "topic": {
+      "type": "keyword",
+      "store": true
+    },
+    "created": {
+      "type": "date",
+      "store": true
+    },
+    "modified": {
+      "type": "date",
+      "store": true
+    },
+    "t04_search.searchterm": {
+      "type": "keyword",
+      "store": true
+    },
+    "t017_url_ref.url_link": {
+      "type": "keyword",
+      "store": true
+    },
+    "t017_url_ref.content": {
+      "type": "keyword",
+      "store": true
+    },
+    "t017_url_ref.special_ref": {
+      "type": "keyword",
+      "store": true
+    },
+    "t017_url_ref.datatype": {
+      "type": "keyword",
+      "store": true
+    },
+    "t01_object.time_type": {
+      "type": "keyword",
+      "store": true
+    },
+    "t01_object.time_from": {
+      "type": "keyword",
+      "store": true
+    },
+    "t01_object.time_to": {
+      "type": "keyword",
+      "store": true
+    },
+    "t0": {
+      "type": "keyword",
+      "store": true
+    },
+    "t1": {
+      "type": "keyword",
+      "store": true
+    },
+    "t2": {
+      "type": "keyword",
+      "store": true
+    },
+    "object_use_constraint.license_key": {
+      "type": "keyword",
+      "store": true
+    },
+    "object_use_constraint.license_value": {
+      "type": "keyword",
+      "store": true
+    },
+    "is_hvd": {
+      "type": "keyword",
+      "store": true
+    },
+    "wkt_geo": {
+      "type": "geo_shape"
+    },
+    "wkt_geo_text": {
+      "type": "text",
+      "store": true
+    },
+    "sort_hash": {
+      "type": "keyword"
+    },
+    "topic_categories": {
+      "type": "keyword",
+      "store": true
+    }
+  }
+}

--- a/server/src/main/resources/templates/export/ingrid-lfubayern/lucene/template-lucene-lfubayern.jte
+++ b/server/src/main/resources/templates/export/ingrid-lfubayern/lucene/template-lucene-lfubayern.jte
@@ -1,0 +1,16 @@
+@import de.ingrid.igeserver.profiles.ingrid_lfubayern.exporter.internal.IngridModelTransformerLfub
+@import gg.jte.support.ForSupport
+@import java.util.Map
+@param Map<String, Object> map
+
+!{var page = ((IngridModelTransformerLfub)map.get("model"));}
+
+
+@template.export.ingrid.lucene.template-lucene(map = map, extraFields = @`
+,
+    "object_node.tree_path.name": [
+    @for(var entry : ForSupport.of(page.getTreePathNames()))
+        "${entry.get()}"@if (!entry.isLast()),@endif
+    @endfor
+    ]
+`)

--- a/server/src/test/kotlin/de/ingrid/igeserver/exports/ingrid_lfubayern/LfuBayernFields.kt
+++ b/server/src/test/kotlin/de/ingrid/igeserver/exports/ingrid_lfubayern/LfuBayernFields.kt
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import de.ingrid.igeserver.DummyCatalog
 import de.ingrid.igeserver.exports.ingrid.GeodatasetBase
 import de.ingrid.igeserver.exports.ingrid.exportJsonToXML
+import de.ingrid.igeserver.persistence.postgresql.jpa.model.ige.DocumentWrapper
 import de.ingrid.igeserver.profiles.ingrid_lfubayern.exporter.IngridIdfExporterLfub
 import io.kotest.core.spec.Spec
 import io.kotest.matchers.string.shouldContain
@@ -56,6 +57,7 @@ class LfuBayernFields : GeodatasetBase() {
         every { codelistHandler.getCatalogCodelistValue(any(), "20000", "2") } returns "geological zwei"
         every { codelistHandler.getCatalogCodelistValue(any(), "20001", "1") } returns "intern eins"
         every { codelistHandler.getCatalogCodelistValue(any(), "20001", "2") } returns "intern zwei"
+        every { documentService.getWrapperByCatalogAndDocumentUuid(any(), any(), any()) } returns DocumentWrapper()
     }
 
     init {


### PR DESCRIPTION
This PR adds IGE folder (i.e. path) information to the LfuBayern profile:

* in the ES field `object_node.tree_path.name`
* in the IDF, at `/idf:html/idf:body/idf:idfMdMetadata/idf:treePath`

The information is used in the Portal to show/filter by this folder information.