### PR TITLE
feature/7832-ogcApiEiaFormat

### DIFF
--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/formatFactory/IngridIsoFormatter.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/formatFactory/IngridIsoFormatter.kt
@@ -118,7 +118,6 @@ class IngridIsoFormatter : BodyFormatter {
         return sw.toString()
     }
 
-    @Throws(ClientException::class)
     fun parseXmlWithMultipleDocs(data: String): String {
         val xmlInput = InputSource(StringReader(data))
         val dbf = DocumentBuilderFactory.newInstance()

--- a/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/formatFactory/IngridIsoFormatter.kt
+++ b/server/src/main/java/de/ingrid/igeserver/features/ogc_api_records/services/formatFactory/IngridIsoFormatter.kt
@@ -54,7 +54,7 @@ class IngridIsoFormatter : BodyFormatter {
         for (catalog in collections) response += catalog.toString().substringAfter("?>")
         response
 
-        val wrappedResponse = wrapperForXml(response, links, queryMetadata)
+        val wrappedResponse = wrapperForXml(response, links, queryMetadata, isSingleRecord)
 
         return wrappedResponse.toByteArray()
     }
@@ -64,13 +64,14 @@ class IngridIsoFormatter : BodyFormatter {
         for (record in records) response += record.result?.toString(Charsets.UTF_8)?.substringAfter("?>")
         response
 
-        val wrappedResponse = wrapperForXml(response, links, queryMetadata)
+        val wrappedResponse = wrapperForXml(response, links, queryMetadata, isSingleRecord)
 
         return wrappedResponse.toByteArray()
     }
 
-    private fun wrapperForXml(responseRecords: String, links: List<Link>?, queryMetadata: QueryMetadata?): String {
-        // TODO Remove "<datasets>" if isSingleRecord ?
+    private fun wrapperForXml(responseRecords: String, links: List<Link>?, queryMetadata: QueryMetadata?, isSingleRecord: Boolean): String {
+        if (isSingleRecord) return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>$responseRecords"
+
         val xmlString = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><datasets>$responseRecords</datasets>"
         if (links == null && queryMetadata == null) return xmlString
 
@@ -117,16 +118,16 @@ class IngridIsoFormatter : BodyFormatter {
         return sw.toString()
     }
 
+    @Throws(ClientException::class)
     fun parseXmlWithMultipleDocs(data: String): String {
-        val documents: MutableList<String> = mutableListOf()
-
         val xmlInput = InputSource(StringReader(data))
         val dbf = DocumentBuilderFactory.newInstance()
         dbf.isNamespaceAware = true
         val doc = dbf.newDocumentBuilder().parse(xmlInput)
 
-        val datasetList = doc.documentElement.getElementsByTagNameNS("http://www.isotc211.org/2005/gmd", "MD_Metadata")
+        if (doc.documentElement.localName == "datasets") throw ClientException.withReason("Invalid XML structure: <gmd:MD_Metadata> must be the document root and must not be wrapped in <datasets>.")
 
+        val datasetList = doc.documentElement.getElementsByTagNameNS("http://www.isotc211.org/2005/gmd", "MD_Metadata")
         if (datasetList.length > 1) throw ClientException.withReason("Invalid request: XML body must contain exactly one 'MD_Metadata' element.")
 
         return data

--- a/server/src/main/java/de/ingrid/igeserver/profiles/uvp/importer/dcatapeia/DcatApEiaMapper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/uvp/importer/dcatapeia/DcatApEiaMapper.kt
@@ -74,7 +74,7 @@ class DcatApEiaMapper(
 
     val pointOfContact: List<Contact>? = run {
         // TODO How to map contacts? -> dcat:contactPoint -> vcard:Organization
-        val mail = dataset.contactPoint?.firstOrNull()?.email
+        // val mail = dataset.contactPoint?.firstOrNull()?.email
         listOf()
     }
 

--- a/server/src/main/java/de/ingrid/igeserver/profiles/uvp/importer/dcatapeia/DcatApEiaMapper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/uvp/importer/dcatapeia/DcatApEiaMapper.kt
@@ -74,7 +74,7 @@ class DcatApEiaMapper(
 
     val pointOfContact: List<Contact>? = run {
         // TODO How to map contacts? -> dcat:contactPoint -> vcard:Organization
-        val mail = dataset.contactPoint.firstOrNull()?.email
+        val mail = dataset.contactPoint?.firstOrNull()?.email
         listOf()
     }
 

--- a/server/src/main/java/de/ingrid/igeserver/profiles/uvp/importer/dcatapeia/DcatApEiaMapper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/uvp/importer/dcatapeia/DcatApEiaMapper.kt
@@ -64,11 +64,11 @@ class DcatApEiaMapper(
     @Suppress("PropertyName")
     val _uuid: String = dataset.identifier?.first() ?: UUID.randomUUID().toString()
 
-    val title = dataset.title.firstOrNull()
+    val title = dataset.title?.firstOrNull() ?: throw ClientException.withReason("DCAT-AP.EIA field 'dct:title' is missing.")
 
-    val description = dataset.description.firstOrNull()?.trimIndent()?.trim()
+    val description = dataset.description?.firstOrNull()?.trimIndent()?.trim()
 
-    val receiptDate = dataset.receiptDate.toString()
+    val receiptDate = dataset.receiptDate?.toString() ?: ""
 
     val prelimAssessment: Boolean = dataset.prelimAssessment
 
@@ -87,7 +87,7 @@ class DcatApEiaMapper(
         // TODO Load language from catalog and include in codelist request
         val catalog = catalogService.getCatalogById(catalogId)
         val uvpCodelistId = behaviourService.get(catalogId, "plugin.uvp.eia-number")?.data?.get("uvpCodelist")?.toString() ?: "9000"
-        val eiaNumbers: List<KeyValue> = dataset.number.map { value ->
+        val eiaNumbers: List<KeyValue>? = dataset.number?.map { value ->
             val key = codelistHandler.getCodeListEntryId(uvpCodelistId, value, "de") ?: throw ClientException.withReason("Element '<eia:number>' of request body contains invalid value '$value'. It does NOT match a codelist entry.")
             KeyValue(key, value, uvpCodelistId)
         }


### PR DESCRIPTION
Remove <datasets> tag from OGC import of ISO records (POST, PUT).
Remove <datasets> tag from OGC export of one record.
Only add <datasets> tag when requesting multiple records.

