### PR TITLE
ISO Import: Trim values (identifier, graphicOverviews, fileReferences, useLimitation, useConstraints)

### DIFF
--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeneralMapper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeneralMapper.kt
@@ -392,7 +392,7 @@ open class GeneralMapper(val isoData: IsoImportData) {
             } else {
                 it.mdBrowseGraphic?.fileName?.value
             }
-            PreviewGraphic(fileName, it.mdBrowseGraphic?.fileDescription?.value, !isInternalStorage)
+            PreviewGraphic(fileName?.trim(), it.mdBrowseGraphic?.fileDescription?.value, !isInternalStorage)
         } ?: emptyList()
 
     data class PreviewGraphic(
@@ -617,7 +617,7 @@ open class GeneralMapper(val isoData: IsoImportData) {
         } ?: emptyList()
 
     fun getUseLimitation(): String = metadata.identificationInfo[0].identificationInfo?.resourceConstraints
-        ?.flatMap { it.legalConstraint?.useLimitation?.mapNotNull { use -> use.value } ?: emptyList() }
+        ?.flatMap { it.legalConstraint?.useLimitation?.mapNotNull { use -> use.value?.replace(Regex("\\s+"), " ")?.trim() } ?: emptyList() }
         ?.joinToString(";") ?: ""
 
     fun getDistributionFormat(): List<DistributionFormat> = metadata.distributionInfo?.mdDistribution?.distributionFormat
@@ -690,7 +690,7 @@ open class GeneralMapper(val isoData: IsoImportData) {
                     val typeId =
                         if (fileFormatCode == null) null else codeListService.getCodeListEntryId("1320", fileFormatCode, "de")
                     val keyValue = if (typeId == null) KeyValue("9999") else KeyValue(typeId)
-                    val fileName = resource.linkage.url?.substringAfterLast('/') ?: ""
+                    val fileName = resource.linkage.url?.substringAfterLast('/')?.trim() ?: ""
                     val sizeInBytes = transferOption.mdDigitalTransferOptions.transferSize?.value?.times(1_000_000)
                     val fileReferenceLink = FileReferenceLink(
                         asLink = false,
@@ -786,7 +786,7 @@ open class GeneralMapper(val isoData: IsoImportData) {
         val otherConstraints = metadata.identificationInfo[0].identificationInfo?.resourceConstraints
             ?.map { it.legalConstraint }
             ?.filter { it?.useConstraints != null }
-            ?.flatMap { legalConstraint -> legalConstraint?.otherConstraints?.mapNotNull { it.value } ?: emptyList() }
+            ?.flatMap { legalConstraint -> legalConstraint?.otherConstraints?.mapNotNull { it.value?.trim() } ?: emptyList() }
             ?: emptyList()
 
         val result = mutableListOf<UseConstraint>()

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeneralMapper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeneralMapper.kt
@@ -617,7 +617,7 @@ open class GeneralMapper(val isoData: IsoImportData) {
         } ?: emptyList()
 
     fun getUseLimitation(): String = metadata.identificationInfo[0].identificationInfo?.resourceConstraints
-        ?.flatMap { it.legalConstraint?.useLimitation?.mapNotNull { use -> use.value?.replace(Regex("\\s+"), " ")?.trim() } ?: emptyList() }
+        ?.flatMap { it.legalConstraint?.useLimitation?.mapNotNull { use -> use.value?.trim() } ?: emptyList() }
         ?.joinToString(";") ?: ""
 
     fun getDistributionFormat(): List<DistributionFormat> = metadata.distributionInfo?.mdDistribution?.distributionFormat

--- a/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeodatasetMapper.kt
+++ b/server/src/main/java/de/ingrid/igeserver/profiles/ingrid/importer/iso19139/GeodatasetMapper.kt
@@ -328,7 +328,7 @@ open class GeodatasetMapper(isoData: IsoImportData) : GeneralMapper(isoData) {
         ?.getOrNull(0) ?: ""
 
     fun getMDIdentifier(): String = identificationInfo?.citation?.citation?.identifier
-        ?.map { it.mdIdentifier?.code?.value }
+        ?.map { it.mdIdentifier?.code?.value?.trim() }
         ?.getOrNull(0) ?: ""
 
     fun getSpatialRepresentationTypes(): List<KeyValue> = identificationInfo?.spatialRepresentationType


### PR DESCRIPTION
Entfernung von Leerzeichen und Zeilenumbrüchen beim Iso Import. Besonders relevant bei graphicOverviews und fileReferences um die Dateien korrekt zu matchen.