### PR TITLE
Refactor dataset expiry handling for consistency and improvements

### DIFF
--- a/frontend/src/app/+reports/+tab-expiration/expiration-table/expiration-table.component.html
+++ b/frontend/src/app/+reports/+tab-expiration/expiration-table/expiration-table.component.html
@@ -49,7 +49,7 @@
             [attr.aria-label]="
                 'Titel: ' +
                 row.title +
-                ', zuletzt bearbeitet: ' +
+                ', zuletzt veröffentlicht: ' +
                 (row._contentModified | dateAgo: 'DE') +
                 ', Verantwortlicher: ' +
                 (row._responsibleUser | fullName | async)

--- a/frontend/src/app/+reports/+tab-expiration/expiration-table/expiration-table.component.html
+++ b/frontend/src/app/+reports/+tab-expiration/expiration-table/expiration-table.component.html
@@ -15,7 +15,7 @@
 
         <ng-container matColumnDef="_contentModified">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>
-                Zuletzt bearbeitet
+                Zuletzt veröffentlicht
             </th>
             <td
                 mat-cell

--- a/frontend/src/app/+reports/+tab-expiration/tab-expiration.component.html
+++ b/frontend/src/app/+reports/+tab-expiration/tab-expiration.component.html
@@ -1,6 +1,6 @@
 <page-template label="Abgelaufene Metadaten">
     <div left-side>
-        @if (expiryDurationInDays()) {
+        @if (expiryFunctionalityActive()) {
             Hier sehen Sie die Metadaten, deren Verfallszeitspanne abgelaufen
             ist und auf die Sie Schreib- oder Leserechte haben.
         } @else {
@@ -12,7 +12,7 @@
     </div>
 
     <div main-header class="flex-col gap-12 align-items-start">
-        @if (expiryDurationInDays() > 0) {
+        @if (expiryFunctionalityActive()) {
             <button
                 mat-flat-button
                 color="primary"
@@ -32,7 +32,7 @@
     </div>
 
     <div main-content>
-        @if (expiryDurationInDays() > 0) {
+        @if (expiryFunctionalityActive()) {
             @let data = showData();
             @if (data) {
                 <div

--- a/frontend/src/app/+reports/+tab-expiration/tab-expiration.component.ts
+++ b/frontend/src/app/+reports/+tab-expiration/tab-expiration.component.ts
@@ -26,14 +26,11 @@ import {
 } from "@angular/core";
 
 import { MatCheckboxModule } from "@angular/material/checkbox";
-import {
-  ResearchResponse,
-  ResearchService,
-} from "../../+research/research.service";
-import { combineLatestWith, concatMap, debounce, of, timer } from "rxjs";
+import { ResearchService } from "../../+research/research.service";
+import { concatMap, debounce, of, timer } from "rxjs";
 import { ExpirationTableComponent } from "./expiration-table/expiration-table.component";
 import { MatButtonModule } from "@angular/material/button";
-import { catchError, filter, map, tap } from "rxjs/operators";
+import { catchError, filter, tap } from "rxjs/operators";
 import { ConfigService } from "../../services/config/config.service";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { MatDividerModule } from "@angular/material/divider";
@@ -43,7 +40,6 @@ import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
 import { NavigationEnd, Router } from "@angular/router";
 import { ExpiredData } from "./tab-expiration.model";
 import { FormsModule } from "@angular/forms";
-import { isExpired } from "../../services/utils";
 import { PageTemplateComponent } from "../../shared/page-template/page-template.component";
 
 @UntilDestroy()
@@ -64,7 +60,7 @@ import { PageTemplateComponent } from "../../shared/page-template/page-template.
 })
 export class TabExpirationComponent implements OnInit {
   currentUserId: number;
-  expiryDurationInDays = signal<number | null>(null);
+  expiryFunctionalityActive = signal<boolean>(false);
 
   isSearching = signal<boolean>(false);
   onSearch = new EventEmitter<void>();
@@ -111,7 +107,9 @@ export class TabExpirationComponent implements OnInit {
       .getExpiryDuration()
       .pipe(
         untilDestroyed(this),
-        tap((expiryDuration) => this.expiryDurationInDays.set(expiryDuration)),
+        tap((expiryDuration) =>
+          this.expiryFunctionalityActive.set(expiryDuration > 0),
+        ),
         tap(() => this.onSearch.emit()),
       )
       .subscribe();
@@ -132,41 +130,12 @@ export class TabExpirationComponent implements OnInit {
   }
 
   private updateResult() {
-    if (!this.expiryDurationInDays()) return of();
+    if (!this.expiryFunctionalityActive()) return of();
 
-    return this.search("selectDocuments").pipe(
-      combineLatestWith(this.search("selectAddresses")),
-      map(([objects, addresses]) =>
-        this.expiredData.set(new ExpiredData(objects.hits, addresses.hits)),
-      ),
+    return this.researchService.getExpiredDatasetStatistics().pipe(
+      tap((expiredData) => this.expiredData.set(expiredData)),
+      catchError((error) => this.updateOnError(error)),
     );
-  }
-
-  private search(type: string) {
-    return this.researchService
-      .search(
-        "",
-        {
-          type: type,
-          state: { exceptFolders: true },
-          selectOnlyPublished: "document1.state = 'PUBLISHED'",
-        },
-        "contentmodified",
-        "ASC",
-        undefined,
-        ["selectOnlyPublished"],
-      )
-      .pipe(
-        catchError((error) => this.updateOnError(error)),
-        map((res) => this.filterByExpiry(res)),
-      );
-  }
-
-  private filterByExpiry(res: ResearchResponse): ResearchResponse {
-    const filtered = res.hits.filter((doc) =>
-      isExpired(doc._contentModified, this.expiryDurationInDays()),
-    );
-    return { totalHits: filtered.length, hits: filtered };
   }
 
   toggleFilter() {
@@ -175,6 +144,6 @@ export class TabExpirationComponent implements OnInit {
 
   private updateOnError(error: any) {
     console.warn("Error during search", error);
-    return of({ totalHits: 0, hits: [] });
+    return of(new ExpiredData([], []));
   }
 }

--- a/frontend/src/app/+reports/+tab-expiration/tab-expiration.model.ts
+++ b/frontend/src/app/+reports/+tab-expiration/tab-expiration.model.ts
@@ -43,6 +43,7 @@ export class ExpiredData {
 }
 // Data structure for expired dataset
 export class ExpiredDataset {
+  wrapperId: number | null = null;
   uuid: string | null = null;
   responsibleUserId: number | null = null;
   responsibleUserLogin: string | null = null;

--- a/frontend/src/app/+reports/+tab-expiration/tab-expiration.model.ts
+++ b/frontend/src/app/+reports/+tab-expiration/tab-expiration.model.ts
@@ -41,3 +41,14 @@ export class ExpiredData {
     return docs?.filter((doc) => doc._responsibleUser == id);
   }
 }
+// Data structure for expired dataset
+export class ExpiredDataset {
+  uuid: string | null = null;
+  responsibleUserId: number | null = null;
+  responsibleUserLogin: string | null = null;
+  title: string | null = null;
+  contentmodified: string | null = null; // OffsetDateTime equivalent in TypeScript is typically represented as ISO string
+  contentmodifiedby: string | null = null;
+  type: string = "";
+  category: string = "";
+}

--- a/frontend/src/app/+research/research.service.ts
+++ b/frontend/src/app/+research/research.service.ts
@@ -37,6 +37,10 @@ import { IgeDocument } from "../models/ige-document";
 import { IgeError } from "../models/ige-error";
 import { QueryStore } from "../store/query/query.store";
 import { GeneralStore } from "../store/general.store";
+import {
+  ExpiredData,
+  ExpiredDataset,
+} from "../+reports/+tab-expiration/tab-expiration.model";
 
 export interface QuickFilter {
   id: string;
@@ -172,6 +176,35 @@ export class ResearchService {
       `${this.configuration.backendUrl}statistic/query`,
       backendQuery.get(),
     );
+  }
+
+  private expiredDatasetToDocument(exData: ExpiredDataset): IgeDocument {
+    return {
+      _uuid: exData.uuid,
+      title: exData.title,
+      _contentModified: exData.contentmodified,
+      _type: exData.type,
+      _parent: null,
+      category: exData.category,
+      _responsibleUser: exData.responsibleUserId,
+    } as IgeDocument;
+  }
+
+  getExpiredDatasetStatistics(): Observable<ExpiredData> {
+    return this.http
+      .get<any>(`${this.configuration.backendUrl}statistic/expiredDatasets`)
+      .pipe(
+        map((data: ExpiredDataset[]) => {
+          return new ExpiredData(
+            data
+              .filter((d) => d.category == "data")
+              .map((item) => this.expiredDatasetToDocument(item)),
+            data
+              .filter((d) => d.category == "address")
+              .map((item) => this.expiredDatasetToDocument(item)),
+          );
+        }),
+      );
   }
 
   fetchQueries(): void {

--- a/server/src/main/java/de/ingrid/igeserver/api/StatisticApi.kt
+++ b/server/src/main/java/de/ingrid/igeserver/api/StatisticApi.kt
@@ -21,6 +21,7 @@ package de.ingrid.igeserver.api
 
 import de.ingrid.igeserver.model.ResearchQuery
 import de.ingrid.igeserver.model.StatisticResponse
+import de.ingrid.igeserver.tasks.ExpiredDataset
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -49,4 +50,8 @@ interface StatisticApi {
         principal: Principal,
         @Parameter(description = "the query with filter definitions") @RequestBody query: ResearchQuery,
     ): ResponseEntity<StatisticResponse>
+
+    @Operation
+    @GetMapping(value = ["/statistic/expiredDatasets"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun expiredDatasets(principal: Principal): ResponseEntity<List<ExpiredDataset>>
 }

--- a/server/src/main/java/de/ingrid/igeserver/api/StatisticApiController.kt
+++ b/server/src/main/java/de/ingrid/igeserver/api/StatisticApiController.kt
@@ -26,6 +26,7 @@ import de.ingrid.igeserver.model.ResearchQuery
 import de.ingrid.igeserver.model.ResearchResponse
 import de.ingrid.igeserver.model.StatisticResponse
 import de.ingrid.igeserver.services.CatalogService
+import de.ingrid.igeserver.services.IgeAclService
 import de.ingrid.igeserver.services.ResearchService
 import de.ingrid.igeserver.tasks.ExpiredDataset
 import de.ingrid.igeserver.tasks.ExpiredDatasetsTask
@@ -34,6 +35,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -49,6 +51,7 @@ class StatisticApiController(
     val authUtils: AuthUtils,
     val catalogService: CatalogService,
     val expiredDatasetsTask: ExpiredDatasetsTask,
+    private val aclService: IgeAclService,
 ) : StatisticApi {
 
     override fun getStatistic(principal: Principal): ResponseEntity<StatisticResponse> {
@@ -209,14 +212,32 @@ class StatisticApiController(
     )
 
     override fun expiredDatasets(principal: Principal): ResponseEntity<List<ExpiredDataset>> {
-        val catalog = catalogService.getCatalogById(catalogService.getCurrentCatalogForPrincipal(principal))
-        val expiryDuration = catalog.settings.config.expiredDatasetConfig?.expiryDuration?.toLong()
+        val catalogId = catalogService.getCurrentCatalogForPrincipal(principal)
+        val catalog = catalogService.getCatalogById(catalogId)
+
+        val expiryDays = catalog.settings.config.expiredDatasetConfig?.expiryDuration?.toLong()
             ?: throw ServerException.withReason("No expiryDuration found for catalog ${catalog.identifier}")
-        val expiredDatasets = expiredDatasetsTask.getPublishedDatasetsEditedBefore(
+
+        val cutoffDate = OffsetDateTime.now().minusDays(expiryDays)
+
+        val expiredCandidates = expiredDatasetsTask.getPublishedDatasetsEditedBefore(
             catalog = catalog,
-            date = OffsetDateTime.now().minusDays(expiryDuration),
+            date = cutoffDate,
             expiryState = null,
         )
-        return ResponseEntity.ok(expiredDatasets)
+
+        val userRoles = authUtils.getCurrentUserRoles(catalog.identifier)
+        val hasRootReadAccess = authUtils.isAdmin(principal) || aclService.hasRootReadAccess(userRoles)
+        val auth = principal as Authentication
+
+        val visible = if (hasRootReadAccess) {
+            expiredCandidates
+        } else {
+            expiredCandidates.filter {
+                aclService.getPermissionInfo(auth, it.wrapperId).canRead
+            }
+        }
+
+        return ResponseEntity.ok(visible)
     }
 }

--- a/server/src/main/java/de/ingrid/igeserver/api/StatisticApiController.kt
+++ b/server/src/main/java/de/ingrid/igeserver/api/StatisticApiController.kt
@@ -19,6 +19,7 @@
  */
 package de.ingrid.igeserver.api
 
+import de.ingrid.igeserver.ServerException
 import de.ingrid.igeserver.model.BoolFilter
 import de.ingrid.igeserver.model.ResearchPaging
 import de.ingrid.igeserver.model.ResearchQuery
@@ -26,6 +27,8 @@ import de.ingrid.igeserver.model.ResearchResponse
 import de.ingrid.igeserver.model.StatisticResponse
 import de.ingrid.igeserver.services.CatalogService
 import de.ingrid.igeserver.services.ResearchService
+import de.ingrid.igeserver.tasks.ExpiredDataset
+import de.ingrid.igeserver.tasks.ExpiredDatasetsTask
 import de.ingrid.igeserver.utils.AuthUtils
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -37,6 +40,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 import java.security.Principal
+import java.time.OffsetDateTime
 
 @RestController
 @RequestMapping(path = ["/api"])
@@ -44,6 +48,7 @@ class StatisticApiController(
     val researchService: ResearchService,
     val authUtils: AuthUtils,
     val catalogService: CatalogService,
+    val expiredDatasetsTask: ExpiredDatasetsTask,
 ) : StatisticApi {
 
     override fun getStatistic(principal: Principal): ResponseEntity<StatisticResponse> {
@@ -129,10 +134,12 @@ class StatisticApiController(
                         allDataWithDraft++
                         statsType.numAllDrafts++
                     }
+
                     "P" -> {
                         allDataPublished++
                         statsType.numPublished++
                     }
+
                     "W" -> {
                         allDataDrafts++
                         statsType.numDrafts++
@@ -179,7 +186,15 @@ class StatisticApiController(
         BoolFilter(
             "AND",
             null,
-            listOfNotNull(stateFilter, userFilter).map { BoolFilter("OR", listOf(it), null, null, isFacet = false) } +
+            listOfNotNull(stateFilter, userFilter).map {
+                BoolFilter(
+                    "OR",
+                    listOf(it),
+                    null,
+                    null,
+                    isFacet = false,
+                )
+            } +
                 BoolFilter(
                     "AND",
                     listOf(typeFilter, "exceptFolders"),
@@ -192,4 +207,16 @@ class StatisticApiController(
         "DESC",
         ResearchPaging(1, 10),
     )
+
+    override fun expiredDatasets(principal: Principal): ResponseEntity<List<ExpiredDataset>> {
+        val catalog = catalogService.getCatalogById(catalogService.getCurrentCatalogForPrincipal(principal))
+        val expiryDuration = catalog.settings.config.expiredDatasetConfig?.expiryDuration?.toLong()
+            ?: throw ServerException.withReason("No expiryDuration found for catalog ${catalog.identifier}")
+        val expiredDatasets = expiredDatasetsTask.getPublishedDatasetsEditedBefore(
+            catalog = catalog,
+            date = OffsetDateTime.now().minusDays(expiryDuration),
+            expiryState = null,
+        )
+        return ResponseEntity.ok(expiredDatasets)
+    }
 }

--- a/server/src/main/java/de/ingrid/igeserver/tasks/ExpiredDatasetsTask.kt
+++ b/server/src/main/java/de/ingrid/igeserver/tasks/ExpiredDatasetsTask.kt
@@ -93,22 +93,16 @@ class ExpiredDatasetsTask(
             val notifyDate =
                 expireDate.plusDays(notifyDaysBeforeExpiry.toLong())
             aboutToExpireDatasets =
-                this.getDatasetsEditedBefore(catalog, notifyDate, ExpiryState.INITIAL, expireDate).map {
-                    this.mapToDataset(it)
-                }
+                this.getPublishedDatasetsEditedBefore(catalog, notifyDate, ExpiryState.INITIAL, expireDate)
             log.info("Found ${aboutToExpireDatasets.size} datasets about to expire for catalog ${catalog.name}")
         } else {
             log.info("Notify days before expiry not set for catalog ${catalog.name}")
         }
 
-        var expiredDatasets = this.getDatasetsEditedBefore(catalog, expireDate, ExpiryState.TO_BE_EXPIRED).map {
-            this.mapToDataset(it)
-        }
+        var expiredDatasets = this.getPublishedDatasetsEditedBefore(catalog, expireDate, ExpiryState.TO_BE_EXPIRED)
         val repeatExpiredDatasets =
             if (repeatExpiryCheck) {
-                this.getDatasetsEditedBefore(catalog, expireDate, ExpiryState.EXPIRED).map {
-                    this.mapToDataset(it)
-                }
+                this.getPublishedDatasetsEditedBefore(catalog, expireDate, ExpiryState.EXPIRED)
             } else {
                 emptyList()
             }
@@ -141,19 +135,21 @@ class ExpiredDatasetsTask(
 
     private fun mapToDataset(dbResponse: Array<Any?>): ExpiredDataset = ExpiredDataset(
         dbResponse[0].toString(),
-        dbResponse[1].toString(),
+        dbResponse[1] as Integer,
         dbResponse[2].toString(),
-        dbResponse[3] as OffsetDateTime,
-        dbResponse[4].toString(),
+        dbResponse[3].toString(),
+        dbResponse[4] as OffsetDateTime,
         dbResponse[5].toString(),
+        dbResponse[6].toString(),
+        dbResponse[7].toString(),
     )
 
-    private fun getDatasetsEditedBefore(
+    fun getPublishedDatasetsEditedBefore(
         catalog: Catalog,
         date: OffsetDateTime,
-        expiryState: ExpiryState = ExpiryState.INITIAL,
+        expiryState: ExpiryState?,
         limitDate: OffsetDateTime? = null,
-    ): List<Array<Any?>> {
+    ): List<ExpiredDataset> {
         val beginDate = limitDate ?: OffsetDateTime.now()
 
         // differ between querying for EXPIRED (to send another expiry email) or for first expiry email !
@@ -163,17 +159,19 @@ class ExpiredDatasetsTask(
         val expiryFilter =
             if (expiryState == ExpiryState.EXPIRED) {
                 "AND dw.expiry_state = :expiryState AND (dw.last_expiry_time IS NULL OR dw.last_expiry_time < :date)"
-            } else {
+            } else if (expiryState != null) {
                 "AND dw.expiry_state <= :expiryState"
+            } else {
+                ""
             }
 
-        val limitDateFilter = if (limitDate != null) "AND d.modified >= :beginDate" else ""
+        val limitDateFilter = if (limitDate != null) "AND d.contentmodified >= :beginDate" else ""
 
         val query = entityManager.createQuery(
             """
-                SELECT d.uuid, dw.responsibleUser.userId, d.title, d.modified, d.modifiedby, dw.category
+                SELECT d.uuid, dw.responsibleUser.id, dw.responsibleUser.userId, d.title, d.contentmodified, d.contentmodifiedby, dw.type, dw.category
                     FROM DocumentWrapper dw, Document d
-                    WHERE dw.uuid = d.uuid AND dw.catalog = :catalog AND dw.type != 'FOLDER' AND dw.deleted != 1 AND d.state = 'PUBLISHED' AND d.modified < :date 
+                    WHERE dw.uuid = d.uuid AND dw.catalog = :catalog AND dw.type != 'FOLDER' AND dw.deleted != 1 AND d.state = 'PUBLISHED' AND d.contentmodified < :date 
                     $limitDateFilter
                     $expiryFilter
                     """,
@@ -181,8 +179,8 @@ class ExpiredDatasetsTask(
         query.setParameter("catalog", catalog)
         query.setParameter("date", date)
         if (limitDate != null) query.setParameter("beginDate", beginDate)
-        query.setParameter("expiryState", expiryState.value)
-        return query.resultList as List<Array<Any?>>
+        if (expiryState != null)query.setParameter("expiryState", expiryState.value)
+        return (query.resultList as List<Array<Any?>>).map { mapToDataset(it) }
     }
 
     fun sendExpiryNotificationMails(
@@ -270,11 +268,13 @@ class ExpiredDatasetsTask(
 
 data class ExpiredDataset(
     var uuid: String? = null,
+    var responsibleUserId: Integer? = null,
     var responsibleUserLogin: String? = null,
     var title: String? = null,
-    var modified: OffsetDateTime? = null,
-    var modifiedBy: String = "",
+    var contentmodified: OffsetDateTime? = null,
+    var contentmodifiedBy: String? = null,
     var type: String = "",
+    var category: String = "",
 )
 
 enum class ExpiryState(val value: Int) {

--- a/server/src/main/java/de/ingrid/igeserver/tasks/ExpiredDatasetsTask.kt
+++ b/server/src/main/java/de/ingrid/igeserver/tasks/ExpiredDatasetsTask.kt
@@ -134,14 +134,15 @@ class ExpiredDatasetsTask(
     }
 
     private fun mapToDataset(dbResponse: Array<Any?>): ExpiredDataset = ExpiredDataset(
-        dbResponse[0].toString(),
-        dbResponse[1] as Integer,
-        dbResponse[2].toString(),
+        dbResponse[0] as Int,
+        dbResponse[1].toString(),
+        dbResponse[2] as Int,
         dbResponse[3].toString(),
-        dbResponse[4] as OffsetDateTime,
-        dbResponse[5].toString(),
+        dbResponse[4].toString(),
+        dbResponse[5] as OffsetDateTime,
         dbResponse[6].toString(),
         dbResponse[7].toString(),
+        dbResponse[8].toString(),
     )
 
     fun getPublishedDatasetsEditedBefore(
@@ -169,7 +170,7 @@ class ExpiredDatasetsTask(
 
         val query = entityManager.createQuery(
             """
-                SELECT d.uuid, dw.responsibleUser.id, dw.responsibleUser.userId, d.title, d.contentmodified, d.contentmodifiedby, dw.type, dw.category
+                SELECT dw.id, d.uuid, dw.responsibleUser.id, dw.responsibleUser.userId, d.title, d.contentmodified, d.contentmodifiedby, dw.type, dw.category
                     FROM DocumentWrapper dw, Document d
                     WHERE dw.uuid = d.uuid AND dw.catalog = :catalog AND dw.type != 'FOLDER' AND dw.deleted != 1 AND d.state = 'PUBLISHED' AND d.contentmodified < :date 
                     $limitDateFilter
@@ -267,8 +268,9 @@ class ExpiredDatasetsTask(
 }
 
 data class ExpiredDataset(
+    var wrapperId: Int? = null,
     var uuid: String? = null,
-    var responsibleUserId: Integer? = null,
+    var responsibleUserId: Int? = null,
     var responsibleUserLogin: String? = null,
     var title: String? = null,
     var contentmodified: OffsetDateTime? = null,

--- a/server/src/main/resources/templates/export/bmi/expired-template.jte
+++ b/server/src/main/resources/templates/export/bmi/expired-template.jte
@@ -17,9 +17,9 @@ Zu prüfende Metadaten:
 @for( ExpiredDataset expDS : documents )
 Titel: ${expDS.getTitle()}
 UUID: ${expDS.getUuid()}
-Geändert am: ${expDS.getModified().toString()}
-Geändert von: ${expDS.getModifiedBy()}
-!{var type = expDS.getType().equals("data") ? "form" : "address";}
+Geändert am: ${expDS.getContentmodified().toString()}
+Geändert von: ${expDS.getContentmodifiedBy()}
+!{var type = expDS.getCategory().equals("data") ? "form" : "address";}
 Direkter Link: ${linkstub + "/" + type + ";id=" + expDS.getUuid()}
 
 @endfor

--- a/server/src/main/resources/templates/export/bmi/will-expire-template.jte
+++ b/server/src/main/resources/templates/export/bmi/will-expire-template.jte
@@ -17,9 +17,9 @@ Zu prüfende Metadaten:
 @for( ExpiredDataset expDS : documents )
 Titel: ${expDS.getTitle()}
 UUID: ${expDS.getUuid()}
-Geändert am: ${expDS.getModified().toString()}
-Geändert von: ${expDS.getModifiedBy()}
-!{var type = expDS.getType().equals("data") ? "form" : "address";}
+Geändert am: ${expDS.getContentmodified().toString()}
+Geändert von: ${expDS.getContentmodifiedBy()}
+!{var type = expDS.getCategory().equals("data") ? "form" : "address";}
 Direkter Link: ${linkstub + "/" + type + ";id=" + expDS.getUuid()}
 
 @endfor

--- a/server/src/main/resources/templates/export/expired-template.jte
+++ b/server/src/main/resources/templates/export/expired-template.jte
@@ -14,9 +14,9 @@ Bitte prüfen Sie, ob die Angaben noch aktuell sind.
 @for( ExpiredDataset expDS : documents )
 Titel: ${expDS.getTitle()}
 Uuid: ${expDS.getUuid()}
-Geändert am: ${expDS.getModified().toString()}
-Geändert von: ${expDS.getModifiedBy()}
-!{var type = expDS.getType().equals("data") ? "form" : "address";}
+Geändert am: ${expDS.getContentmodified().toString()}
+Geändert von: ${expDS.getContentmodifiedBy()}
+!{var type = expDS.getCategory().equals("data") ? "form" : "address";}
 Direkter Link: ${linkstub + "/" + type + ";id=" + expDS.getUuid()}
 
 @endfor

--- a/server/src/main/resources/templates/export/ingrid-lfubayern/expired-template.jte
+++ b/server/src/main/resources/templates/export/ingrid-lfubayern/expired-template.jte
@@ -15,9 +15,9 @@ Bitte prüfen Sie, ob die Angaben noch aktuell sind und speichern/veröffentlich
 @for( ExpiredDataset expDS : documents )
 Titel: ${expDS.getTitle()}
 UUID: ${expDS.getUuid()}
-Geändert am: ${expDS.getModified().toString()}
-Geändert von: ${expDS.getModifiedBy()}
-!{var type = expDS.getType().equals("data") ? "form" : "address";}
+Geändert am: ${expDS.getContentmodified().toString()}
+Geändert von: ${expDS.getContentmodifiedBy()}
+!{var type = expDS.getCategory().equals("data") ? "form" : "address";}
 Direkter Link: ${linkstub + "/" + type + ";id=" + expDS.getUuid()}
 
 @endfor

--- a/server/src/main/resources/templates/export/will-expire-template.jte
+++ b/server/src/main/resources/templates/export/will-expire-template.jte
@@ -14,8 +14,8 @@ Bitte prüfen Sie, ob die Angaben noch aktuell sind.
 @for( ExpiredDataset expDS : documents )
     Titel: ${expDS.getTitle()}
     Uuid: ${expDS.getUuid()}
-    Geändert am: ${expDS.getModified().toString()}
-    Geändert von: ${expDS.getModifiedBy()}
+    Geändert am: ${expDS.getContentmodified().toString()}
+    Geändert von: ${expDS.getContentmodifiedBy()}
     Direkter Link: ${linkstub + "/form;id=" + expDS.getUuid()}
 
 @endfor


### PR DESCRIPTION
- ExpiredDatasetsTask.kt and tab-expiration.component.html now both use the same DB call
- Changed `modified` and `modifiedBy` to use`contentmodified` and `contentmodifiedBy` instead across templates and models.
- Enhanced backend logic to improve filtering for published datasets and manage expiry notifications.
- Updated frontend to use new APIs for expired dataset statistics, with improved state handling using signals.
- Adjusted translations and UI labels for clarity in expiration-related components and templates.