### PR TITLE
Add migration for DOI codelists

### DIFF
--- a/server/src/main/java/de/ingrid/igeserver/migrations/tasks/M098UpdateInGridDoiCatalogCodelists.kt
+++ b/server/src/main/java/de/ingrid/igeserver/migrations/tasks/M098UpdateInGridDoiCatalogCodelists.kt
@@ -1,0 +1,59 @@
+/**
+ * ==================================================
+ * Copyright (C) 2023-2025 wemove digital solutions GmbH
+ * ==================================================
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be
+ * approved by the European Commission - subsequent versions of the
+ * EUPL (the "Licence");
+ *
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package de.ingrid.igeserver.migrations.tasks
+
+import de.ingrid.igeserver.migrations.MigrationBase
+import de.ingrid.igeserver.persistence.postgresql.jpa.ClosableTransaction
+import de.ingrid.igeserver.profiles.ingrid.InGridProfile
+import de.ingrid.igeserver.repository.CatalogRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+import org.springframework.transaction.PlatformTransactionManager
+
+@Profile("ingrid")
+@Service
+class M098UpdateInGridDoiCatalogCodelists : MigrationBase("0.98") {
+
+    @Autowired
+    private lateinit var transactionManager: PlatformTransactionManager
+
+    @Autowired
+    private lateinit var catalogRepo: CatalogRepository
+
+    @Qualifier("inGridProfile")
+    @Autowired
+    private lateinit var ingridProfile: InGridProfile
+
+    override fun exec() {
+        ClosableTransaction(transactionManager).use {
+            catalogRepo.findAllByType("ingrid").forEach { catalog ->
+                var catalogCodelists = ingridProfile.codelistHandler.getCatalogCodelists(catalog.identifier)
+                if (catalogCodelists.none { it.id == "3386" }) {
+                    ingridProfile.initCatalogCodelists(catalog.identifier, "3386")
+                }
+                if (catalogCodelists.none { it.id == "3390" }) {
+                    ingridProfile.initCatalogCodelists(catalog.identifier, "3390")
+                }
+            }
+        }
+    }
+}

--- a/server/src/main/java/de/ingrid/igeserver/migrations/tasks/M098UpdateInGridDoiCatalogCodelists.kt
+++ b/server/src/main/java/de/ingrid/igeserver/migrations/tasks/M098UpdateInGridDoiCatalogCodelists.kt
@@ -45,7 +45,8 @@ class M098UpdateInGridDoiCatalogCodelists : MigrationBase("0.98") {
 
     override fun exec() {
         ClosableTransaction(transactionManager).use {
-            catalogRepo.findAllByType("ingrid").forEach { catalog ->
+            var ingridCatalogs = catalogRepo.findAll()?.filter { it.type.startsWith("ingrid") }
+            ingridCatalogs?.forEach { catalog ->
                 var catalogCodelists = ingridProfile.codelistHandler.getCatalogCodelists(catalog.identifier)
                 if (catalogCodelists.none { it.id == "3386" }) {
                     ingridProfile.initCatalogCodelists(catalog.identifier, "3386")


### PR DESCRIPTION
Migration für die DOI Codelisten, basierend auf `M071UpdateInGridCatalogCodelists.kt`.

Initialisiert die Codelisten (löschen und hinzufügen), aber nur, wenn sie noch nicht vorhanden sind.