### PR TITLE
Fix print comparison view not marking all changes (#7699)

### DIFF
--- a/frontend/src/app/+form/dialogs/print-view/print-view.plugin.ts
+++ b/frontend/src/app/+form/dialogs/print-view/print-view.plugin.ts
@@ -34,7 +34,7 @@ import { clone, JsonDiffMerge } from "../../../shared/utils";
 import { Plugin } from "../../../+catalog/+behaviours/plugin";
 import { PluginService } from "../../../services/plugin/plugin.service";
 import { FormlyFieldConfig } from "@ngx-formly/core";
-import { deepMerge } from "../../../services/utils";
+import { cleanObject, deepMerge } from "../../../services/utils";
 
 @UntilDestroy()
 @Injectable()
@@ -108,11 +108,15 @@ export class PrintViewPlugin extends Plugin {
           published.documentWithMetadata,
           {},
         );
-        const diffForward = JsonDiffMerge.jsonDiff(
+        let diffForward = JsonDiffMerge.jsonDiff(
           published.documentWithMetadata,
           current.documentWithMetadata,
           {},
         );
+        // remove "empty" changes - otherwise, a mis-classification can occur
+        // if a previously non-set published field is
+        // first set to a value and saved, and then unset and saved
+        diffForward = cleanObject(diffForward);
         // the actual diff contents are negligible because we only need the changed fields
         const diff = deepMerge({}, diffBackward, diffForward);
         fields = doctype.getFieldsForPrint(diff);

--- a/frontend/src/app/+form/dialogs/print-view/print-view.plugin.ts
+++ b/frontend/src/app/+form/dialogs/print-view/print-view.plugin.ts
@@ -34,6 +34,7 @@ import { clone, JsonDiffMerge } from "../../../shared/utils";
 import { Plugin } from "../../../+catalog/+behaviours/plugin";
 import { PluginService } from "../../../services/plugin/plugin.service";
 import { FormlyFieldConfig } from "@ngx-formly/core";
+import { deepMerge } from "../../../services/utils";
 
 @UntilDestroy()
 @Injectable()
@@ -102,11 +103,18 @@ export class PrintViewPlugin extends Plugin {
       let fields: FormlyFieldConfig[];
       let fieldsPublished = null;
       if (published !== null) {
-        const diff = JsonDiffMerge.jsonDiff(
+        const diffBackward = JsonDiffMerge.jsonDiff(
           current.documentWithMetadata,
           published.documentWithMetadata,
           {},
         );
+        const diffForward = JsonDiffMerge.jsonDiff(
+          published.documentWithMetadata,
+          current.documentWithMetadata,
+          {},
+        );
+        // the actual diff contents are negligible because we only need the changed fields
+        const diff = deepMerge({}, diffBackward, diffForward);
         fields = doctype.getFieldsForPrint(diff);
         fieldsPublished = clone(fields);
       } else {

--- a/frontend/src/app/services/utils.ts
+++ b/frontend/src/app/services/utils.ts
@@ -148,3 +148,24 @@ export function waitForCondition(
     catchError(() => of(false)),
   );
 }
+
+/**
+ * Recursively cleans an object of empty fields (null, undefined, empty string).
+ * @param obj The object to be cleaned
+ * @returns The same object, cleaned of empty fields (in-place changes)
+ */
+export function cleanObject(obj) {
+  for (const key in obj) {
+    if (obj[key] == null || obj[key] === "") {
+      delete obj[key];
+    } else if (Array.isArray(obj[key]) && obj[key].length === 0) {
+      delete obj[key];
+    } else if (typeof obj[key] === "object" && !Array.isArray(obj[key])) {
+      cleanObject(obj[key]);
+      if (Object.keys(obj[key]).length === 0) {
+        delete obj[key];
+      }
+    }
+  }
+  return obj;
+}

--- a/frontend/src/app/shared/utils.ts
+++ b/frontend/src/app/shared/utils.ts
@@ -161,6 +161,7 @@ export function removeNullOrEmptyFields(obj: any) {
 /*!
  * JsonDiffMerge Library v1
  * https://debugtopinpoint.wordpress.com/
+ * https://github.com/ryanshane/JsonDiffMerge
  *
  * Ryan Steller
  *

--- a/frontend/src/profiles/base.doctype.ts
+++ b/frontend/src/profiles/base.doctype.ts
@@ -374,9 +374,8 @@ export abstract class BaseDoctype extends FormFieldHelper implements Doctype {
       ?.filter((field) => !field.props?.hideInPreview);
   }
 
-  private calcIsDifferent(field, diffObj): boolean {
+  private calcIsDifferent(path: string[], diffObj): boolean {
     if (!diffObj) return false;
-    const path = this.getKeyPath(field);
     if (!path.length) return false;
     let diff = diffObj;
     for (const key of path) {
@@ -389,18 +388,24 @@ export abstract class BaseDoctype extends FormFieldHelper implements Doctype {
     return true;
   }
 
-  addDifferenceFlags(fields: FormlyFieldConfig[], diffObj) {
+  addDifferenceFlags(fields: FormlyFieldConfig[], diffObj, path: any[] = []) {
     fields?.forEach((field) => {
+      let extendedPath = [...path];
+      if (field.key) {
+        extendedPath.push(field.key);
+      }
       if (field.fieldGroup) {
-        this.addDifferenceFlags(field.fieldGroup, diffObj);
+        this.addDifferenceFlags(field.fieldGroup, diffObj, extendedPath);
       }
       if (field.fieldArray) {
         this.addDifferenceFlags(
           (<FormlyFieldConfig>field.fieldArray).fieldGroup,
           diffObj,
+          extendedPath,
         );
       }
-      if (this.calcIsDifferent(field, diffObj)) {
+      // we need to check for field groups because otherwise we would mark the whole group as different too
+      if (this.calcIsDifferent(extendedPath, diffObj) && !field.fieldGroup) {
         field.className = field.className
           ? field.className + " mark-different"
           : "mark-different";
@@ -408,16 +413,6 @@ export abstract class BaseDoctype extends FormFieldHelper implements Doctype {
         field.className = field.className?.replace("mark-different", "");
       }
     });
-  }
-
-  getKeyPath(field): string[] {
-    if (field.parent) {
-      return field.key
-        ? this.getKeyPath(field.parent).concat([field.key.toString()])
-        : this.getKeyPath(field.parent);
-    } else {
-      return field.key ? [field.key.toString()] : [];
-    }
   }
 
   private getFormatterForColumn(

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1358,6 +1358,7 @@ table.big-font {
   ige-print-type,
   ige-date-range-type,
   ige-spatial-list,
+  ige-metadata-type > div,
   formly-field-mat-datepicker,
   .mat-mdc-radio-group {
     background: vars.$error-background !important;
@@ -1368,6 +1369,7 @@ table.big-font {
   ige-print-type,
   ige-date-range-type,
   ige-spatial-list,
+  ige-metadata-type > div,
   formly-field-mat-datepicker,
   .mat-mdc-radio-group {
     background: vars.$ige-check-background-color !important;


### PR DESCRIPTION
In der Anzeige-Logik wird nur die Erkennung von geänderten Feldern benötigt, nicht die tatsächlichen Änderungen.
Daher ist es ausreichend, einen zusätzlichen diff in der anderen Richtung auszuführen und beide diffs zu mergen, um alle geänderten Felder zu finden.