### PR TITLE
Raumbezugssystem-Codeliste durch Anbindung externe Registry erweitern

### DIFF
--- a/frontend/src/app/formly/types/repeat-list/external-result-cache.ts
+++ b/frontend/src/app/formly/types/repeat-list/external-result-cache.ts
@@ -1,0 +1,67 @@
+/**
+ * ==================================================
+ * Copyright (C) 2023-2025 wemove digital solutions GmbH
+ * ==================================================
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be
+ * approved by the European Commission - subsequent versions of the
+ * EUPL (the "Licence");
+ *
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+import { SelectOption } from "../../../services/codelist/codelist.service";
+
+const MAX_CACHE_SIZE = 500;
+
+export class ExternalResultsCache {
+  private cache: SelectOption[] = [];
+
+  constructor(
+    private deduplicate: (
+      options: SelectOption[],
+      externalOptions: SelectOption[],
+    ) => SelectOption[],
+  ) {}
+
+  /**
+   * Adds new results to the cache, deduplicates against existing items, and prunes the array
+   * to maintain the MAX_CACHE_SIZE limit (keeping the most recent entries).
+   *
+   * @param newResults The fresh results fetched from the API (converted to SelectOptionUi)
+   */
+  public updateCache(newResults: SelectOption[]): void {
+    let updatedCache = this.deduplicate(this.cache, newResults);
+    this.cache = updatedCache.slice(-MAX_CACHE_SIZE);
+  }
+
+  /**
+   * Returns a list of cached options that match the current query string.
+   * This is used for providing immediate UX feedback during refinement.
+   *
+   * @param query The current input string
+   * @returns A list of filtered SelectOptionUi items
+   */
+  public filter(query: string): SelectOption[] {
+    if (!query) return [];
+    const lowerQuery = query.toLowerCase();
+
+    return this.cache.filter((option) =>
+      option.label.toLowerCase().includes(lowerQuery),
+    );
+  }
+
+  /**
+   * Clears the cache.
+   */
+  public clear(): void {
+    this.cache = [];
+  }
+}

--- a/frontend/src/app/formly/types/repeat-list/options-scroll.directive.ts
+++ b/frontend/src/app/formly/types/repeat-list/options-scroll.directive.ts
@@ -17,16 +17,10 @@
  * See the Licence for the specific language governing permissions and
  * limitations under the Licence.
  */
-import {
-  Directive,
-  EventEmitter,
-  Input,
-  OnDestroy,
-  Output,
-} from "@angular/core";
-import { Subject } from "rxjs";
-import { takeUntil, tap } from "rxjs/operators";
+import { Directive, EventEmitter, Input, Output } from "@angular/core";
+import { tap } from "rxjs/operators";
 import { MatAutocomplete } from "@angular/material/autocomplete";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 
 export interface IAutoCompleteScrollEvent {
   autoComplete: MatAutocomplete;
@@ -36,11 +30,10 @@ export interface IAutoCompleteScrollEvent {
 @Directive({
   selector: "mat-autocomplete[optionsScroll]",
 })
-export class OptionsScrollDirective implements OnDestroy {
+export class OptionsScrollDirective {
   @Input() thresholdPercent = 0.95;
   @Output("optionsScroll") scroll =
     new EventEmitter<IAutoCompleteScrollEvent>();
-  _onDestroy = new Subject();
 
   constructor(public autoComplete: MatAutocomplete) {
     this.autoComplete.opened
@@ -58,14 +51,14 @@ export class OptionsScrollDirective implements OnDestroy {
             );
           });
         }),
-        takeUntil(this._onDestroy),
+        takeUntilDestroyed(),
       )
       .subscribe();
 
     this.autoComplete.closed
       .pipe(
         tap(() => this.removeScrollEventListener()),
-        takeUntil(this._onDestroy),
+        takeUntilDestroyed(),
       )
       .subscribe();
   }
@@ -75,13 +68,6 @@ export class OptionsScrollDirective implements OnDestroy {
       "scroll",
       this.onScroll,
     );
-  }
-
-  ngOnDestroy() {
-    // this._onDestroy.next();
-    this._onDestroy.complete();
-
-    this.removeScrollEventListener();
   }
 
   onScroll(event: Event) {

--- a/frontend/src/app/formly/types/repeat-list/options-scroll.directive.ts
+++ b/frontend/src/app/formly/types/repeat-list/options-scroll.directive.ts
@@ -1,0 +1,108 @@
+/**
+ * ==================================================
+ * Copyright (C) 2023-2025 wemove digital solutions GmbH
+ * ==================================================
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be
+ * approved by the European Commission - subsequent versions of the
+ * EUPL (the "Licence");
+ *
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+import {
+  Directive,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  Output,
+} from "@angular/core";
+import { Subject } from "rxjs";
+import { takeUntil, tap } from "rxjs/operators";
+import { MatAutocomplete } from "@angular/material/autocomplete";
+
+export interface IAutoCompleteScrollEvent {
+  autoComplete: MatAutocomplete;
+  scrollEvent: Event;
+}
+
+@Directive({
+  selector: "mat-autocomplete[optionsScroll]",
+})
+export class OptionsScrollDirective implements OnDestroy {
+  @Input() thresholdPercent = 0.95;
+  @Output("optionsScroll") scroll =
+    new EventEmitter<IAutoCompleteScrollEvent>();
+  _onDestroy = new Subject();
+
+  constructor(public autoComplete: MatAutocomplete) {
+    this.autoComplete.opened
+      .pipe(
+        tap(() => {
+          // Note: When autocomplete raises opened, panel is not yet created (by Overlay)
+          // Note: The panel will be available on next tick
+          // Note: The panel wil NOT open if there are no options to display
+          setTimeout(() => {
+            // Note: remove listner just for safety, in case the close event is skipped.
+            this.removeScrollEventListener();
+            this.autoComplete.panel.nativeElement.addEventListener(
+              "scroll",
+              this.onScroll.bind(this),
+            );
+          });
+        }),
+        takeUntil(this._onDestroy),
+      )
+      .subscribe();
+
+    this.autoComplete.closed
+      .pipe(
+        tap(() => this.removeScrollEventListener()),
+        takeUntil(this._onDestroy),
+      )
+      .subscribe();
+  }
+
+  private removeScrollEventListener() {
+    this.autoComplete.panel.nativeElement.removeEventListener(
+      "scroll",
+      this.onScroll,
+    );
+  }
+
+  ngOnDestroy() {
+    // this._onDestroy.next();
+    this._onDestroy.complete();
+
+    this.removeScrollEventListener();
+  }
+
+  onScroll(event: Event) {
+    if (this.thresholdPercent === undefined) {
+      this.scroll.next({ autoComplete: this.autoComplete, scrollEvent: event });
+    } else {
+      const threshold =
+        (this.thresholdPercent *
+          100 *
+          (<HTMLInputElement>event.target).scrollHeight) /
+        100;
+      const current =
+        (<HTMLInputElement>event.target).scrollTop +
+        (<HTMLInputElement>event.target).clientHeight;
+
+      if (current > threshold) {
+        this.scroll.next({
+          autoComplete: this.autoComplete,
+          scrollEvent: event,
+        });
+      }
+    }
+  }
+}

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.html
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.html
@@ -72,7 +72,7 @@
         (cdkDropListDropped)="drop($event)"
         role="list"
     >
-        @for (item of items(); track item; let i = $index) {
+        @for (item of items(); track item.value; let i = $index) {
             <div
                 cdkDrag
                 [cdkDragDisabled]="
@@ -150,7 +150,7 @@
                     ></ngx-mat-select-search>
                 </mat-option>
             }
-            @for (option of filteredOptions(); track option.value) {
+            @for (option of filteredOptions(); track option.label) {
                 @if (option.value === "_SEPARATOR_") {
                     <mat-divider class="space-bottom"></mat-divider>
                 } @else {
@@ -196,7 +196,7 @@
             #auto="matAutocomplete"
             (optionSelected)="addToList($event.option.value)"
         >
-            @for (option of filteredOptions(); track option.value) {
+            @for (option of filteredOptions(); track option.label) {
                 @if (option.value === "_SEPARATOR_") {
                     <mat-divider class="space-bottom"></mat-divider>
                 } @else {

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.html
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.html
@@ -198,27 +198,27 @@
             (optionsScroll)="onScroll()"
         >
             @for (option of filteredOptions(); track option.label) {
-                @if (option.value === "_LOADING_SPINNER_") {
-                    <mat-option
-                        [disabled]="true"
-                        class="loading-spinner-option"
-                    >
-                        <div class="spinner-container">
-                            <mat-progress-spinner
-                                mode="indeterminate"
-                                diameter="20"
-                            >
-                            </mat-progress-spinner>
-                            <span class="loading-text">{{ option.label }}</span>
-                        </div>
-                    </mat-option>
-                } @else if (option.value === "_SEPARATOR_") {
+                @if (option.value === "_SEPARATOR_") {
                     <mat-divider class="space-bottom"></mat-divider>
                 } @else {
                     <mat-option [value]="option" [disabled]="option.disabled">
                         {{ option.label }}
                     </mat-option>
                 }
+            }
+            @if (paginationState.isLoading) {
+                <mat-option [disabled]="true" class="loading-spinner-option">
+                    <div class="spinner-container">
+                        <mat-progress-spinner
+                            mode="indeterminate"
+                            diameter="20"
+                        >
+                        </mat-progress-spinner>
+                        <span class="loading-text">
+                            Lädt externe Codelist-Einträge...
+                        </span>
+                    </div>
+                </mat-option>
             }
         </mat-autocomplete>
         <!-- clean button -->

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.html
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.html
@@ -195,6 +195,7 @@
         <mat-autocomplete
             #auto="matAutocomplete"
             (optionSelected)="addToList($event.option.value)"
+            (optionsScroll)="onScroll()"
         >
             @for (option of filteredOptions(); track option.label) {
                 @if (option.value === "_LOADING_SPINNER_") {

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.html
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.html
@@ -197,7 +197,21 @@
             (optionSelected)="addToList($event.option.value)"
         >
             @for (option of filteredOptions(); track option.label) {
-                @if (option.value === "_SEPARATOR_") {
+                @if (option.value === "_LOADING_SPINNER_") {
+                    <mat-option
+                        [disabled]="true"
+                        class="loading-spinner-option"
+                    >
+                        <div class="spinner-container">
+                            <mat-progress-spinner
+                                mode="indeterminate"
+                                diameter="20"
+                            >
+                            </mat-progress-spinner>
+                            <span class="loading-text">{{ option.label }}</span>
+                        </div>
+                    </mat-option>
+                } @else if (option.value === "_SEPARATOR_") {
                     <mat-divider class="space-bottom"></mat-divider>
                 } @else {
                     <mat-option [value]="option" [disabled]="option.disabled">

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.scss
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.scss
@@ -125,3 +125,19 @@ mat-spinner {
   display: inline-block;
   margin-right: 8px;
 }
+
+.loading-spinner-option {
+  height: 36px;
+  line-height: 36px;
+  cursor: default !important;
+}
+
+.spinner-container {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.loading-text {
+  color: #9e9e9e;
+}

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
@@ -306,10 +306,17 @@ export class RepeatListComponent
                   .pipe(catchError(() => of([])));
               }
               return remoteCall$.pipe(
-                map((remoteResults: any[]) => [
-                  ...localResults,
-                  ...remoteResults,
-                ]),
+                map((remoteResults: any[]) => {
+                  const localLabels = localResults.map((r) =>
+                    r.label.toLowerCase(),
+                  );
+                  return [
+                    ...localResults,
+                    ...remoteResults.filter(
+                      (r) => !localLabels.includes(r.label.toLowerCase()),
+                    ),
+                  ];
+                }),
               );
             }),
             tap((value) => this._markSelected(value)), // Mark selected based on combined list

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
@@ -45,7 +45,7 @@ import {
   switchMap,
   tap,
 } from "rxjs/operators";
-import { merge, Observable, of, Subject, Subscription } from "rxjs";
+import { concat, merge, Observable, of, Subject, Subscription } from "rxjs";
 import {
   SelectOption,
   SelectOptionUi,
@@ -101,6 +101,11 @@ class MyErrorStateMatcher implements ErrorStateMatcher {
     else return false;
   }
 }
+
+const LOADING_INDICATOR: SelectOption = new SelectOption(
+  "_LOADING_SPINNER_",
+  "Lädt externe Codelist-Einträge...",
+);
 
 export interface RepeatListProps extends FormlyFieldProps {
   asSelect: boolean;
@@ -298,29 +303,29 @@ export class RepeatListComponent
           startWith(""),
           debounceTime(50),
           tap(() => this.formControl.updateValueAndValidity()),
-        )
-        .pipe(
           switchMap((query: string) => {
             const localResults = this._filter(query);
-            let remoteCall$: Observable<any[]> = of([]);
             if (
               query &&
               query.length >= (this.props.externalOptions.threshold ?? 3)
             ) {
-              remoteCall$ = this.props.externalOptions
-                .fetchCodelist(query, 0)
-                .pipe(catchError(() => of([])));
+              const initialStream = of([...localResults, LOADING_INDICATOR]);
+              const remoteCall$: Observable<SelectOptionUi[]> =
+                this.props.externalOptions.fetchCodelist(query, 0).pipe(
+                  catchError(() => of([])),
+                  map((remoteResults) =>
+                    this.props.externalOptions.deduplicate(
+                      localResults,
+                      remoteResults,
+                    ),
+                  ),
+                );
+              return concat(initialStream, remoteCall$);
+            } else {
+              return of(localResults);
             }
-            return remoteCall$.pipe(
-              map((remoteResults) =>
-                this.props.externalOptions.deduplicate(
-                  localResults,
-                  remoteResults,
-                ),
-              ),
-            );
           }),
-          tap((value) => this._markSelected(value)), // Mark selected based on combined list
+          tap((value) => this._markSelected(value)),
         )
         .subscribe((value) => this.filteredOptions.set(value));
     } else if (this.props.restCall) {

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
@@ -125,6 +125,7 @@ export interface RepeatListProps extends FormlyFieldProps {
   convert: (item: any) => string;
   hideInputField: boolean;
   externalOptions?: {
+    fetchCodelist: (query: string, page: number) => Observable<any[]>;
     deduplicate: (
       options: SelectOption[],
       externalOptions: SelectOption[],
@@ -231,7 +232,7 @@ export class RepeatListComponent
           .pipe(untilDestroyed(this))
           .subscribe((value) => this.manualUpdate.next(value));
       }
-    } else if (this.props.restCall && !this.props.options) {
+    } else if (this.props.restCall) {
       this.type.set("search");
       if (!this.props.labelField) this.props.labelField = "label";
       if (!this.props.selectLabelField)
@@ -290,50 +291,48 @@ export class RepeatListComponent
           : this.inputControl.enable();
       });
 
-    if (this.props.restCall) {
-      if (this.props.options) {
-        this.inputControl.valueChanges
-          .pipe(
-            untilDestroyed(this),
-            startWith(""),
-            debounceTime(50),
-            tap(() => this.formControl.updateValueAndValidity()),
-          )
-          .pipe(
-            switchMap((query: string) => {
-              const localResults = this._filter(query);
-              let remoteCall$: Observable<any[]> = of([]);
-              if (
-                query &&
-                query.length >= (this.props.externalOptions.threshold ?? 3)
-              ) {
-                remoteCall$ = this.props
-                  .restCall(query)
-                  .pipe(catchError(() => of([])));
-              }
-              return remoteCall$.pipe(
-                map((remoteResults) =>
-                  this.props.externalOptions.deduplicate(
-                    localResults,
-                    remoteResults,
-                  ),
+    if (this.props.externalOptions) {
+      this.inputControl.valueChanges
+        .pipe(
+          untilDestroyed(this),
+          startWith(""),
+          debounceTime(50),
+          tap(() => this.formControl.updateValueAndValidity()),
+        )
+        .pipe(
+          switchMap((query: string) => {
+            const localResults = this._filter(query);
+            let remoteCall$: Observable<any[]> = of([]);
+            if (
+              query &&
+              query.length >= (this.props.externalOptions.threshold ?? 3)
+            ) {
+              remoteCall$ = this.props.externalOptions
+                .fetchCodelist(query, 0)
+                .pipe(catchError(() => of([])));
+            }
+            return remoteCall$.pipe(
+              map((remoteResults) =>
+                this.props.externalOptions.deduplicate(
+                  localResults,
+                  remoteResults,
                 ),
-              );
-            }),
-            tap((value) => this._markSelected(value)), // Mark selected based on combined list
-          )
-          .subscribe((value) => this.filteredOptions.set(value));
-      } else {
-        this.inputControl.valueChanges
-          .pipe(
-            untilDestroyed(this),
-            startWith(""),
-            debounceTime(300),
-            tap(() => this.formControl.updateValueAndValidity()),
-            filter((query) => query?.length > 1),
-          )
-          .subscribe((query) => this.search(query));
-      }
+              ),
+            );
+          }),
+          tap((value) => this._markSelected(value)), // Mark selected based on combined list
+        )
+        .subscribe((value) => this.filteredOptions.set(value));
+    } else if (this.props.restCall) {
+      this.inputControl.valueChanges
+        .pipe(
+          untilDestroyed(this),
+          startWith(""),
+          debounceTime(300),
+          tap(() => this.formControl.updateValueAndValidity()),
+          filter((query) => query?.length > 1),
+        )
+        .subscribe((query) => this.search(query));
     } else {
       merge(
         this.formControl.valueChanges,

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
@@ -41,13 +41,17 @@ import {
   distinctUntilChanged,
   filter,
   map,
+  scan,
+  skip,
   startWith,
   switchMap,
   takeUntil,
   tap,
 } from "rxjs/operators";
 import {
+  BehaviorSubject,
   concat,
+  concatMap,
   merge,
   Observable,
   of,
@@ -105,6 +109,7 @@ import {
   PagedSearchResult,
 } from "../../../store/codelist/codelist.model";
 import { ExternalResultsCache } from "./external-result-cache";
+import { OptionsScrollDirective } from "./options-scroll.directive";
 
 class MyErrorStateMatcher implements ErrorStateMatcher {
   constructor(private component: RepeatListComponent) {}
@@ -191,6 +196,7 @@ export interface RepeatListProps extends FormlyFieldProps {
     MatProgressSpinner,
     FieldToAiraLabelledbyPipe,
     FormlyValidationMessage,
+    OptionsScrollDirective,
   ],
 })
 export class RepeatListComponent
@@ -202,6 +208,14 @@ export class RepeatListComponent
   readonly autoCompleteEl = viewChild("repeatListInput", { read: ElementRef });
   readonly autoComplete = viewChild(MatAutocompleteTrigger);
   readonly selector = viewChild(MatSelect);
+
+  private destroy$ = new Subject<void>();
+  private loadMore = new Subject<void>();
+  private paginationState = {
+    page: 0,
+    totalPages: 1,
+    isLoading: false,
+  };
 
   onItemClick: (id: number) => void = () => {};
 
@@ -328,51 +342,117 @@ export class RepeatListComponent
   }
 
   handleExternalOptions() {
-    this.inputControl.valueChanges
-      .pipe(
-        untilDestroyed(this),
-        startWith(""),
-        tap(() => this.formControl.updateValueAndValidity()),
-        switchMap((query: string) => {
-          const localResults = this._filter(query);
-          if (query?.length >= (this.props.externalOptions.threshold ?? 3)) {
-            const cachedFilteredResults =
-              this.externalResultsCache.filter(query);
-            let immediateResults = this.props.externalOptions.deduplicate(
-              localResults,
-              cachedFilteredResults,
-            );
-            // the timer before fetching a codelist from the backend is a simulated debounce, to prevent intermittant requests while a user is still typing
-            const remoteCallCompleted$ = timer(50).pipe(
-              switchMap(() =>
-                this.props.externalOptions.fetchCodelist(query, 0),
-              ),
-              catchError(() => of(EMPTY_PAGED_SEARCH_RESULT)),
-              map((remoteResults: PagedSearchResult) => {
-                const newExternalResults = remoteResults.results.map(
-                  (label) => new SelectOption(null, label),
-                );
-                this.externalResultsCache.updateCache(newExternalResults);
-                return this.props.externalOptions.deduplicate(
-                  localResults,
-                  newExternalResults,
-                );
-              }),
-            );
+    const query$ = this.inputControl.valueChanges.pipe(
+      startWith(this.inputControl.value),
+      map((value) => (typeof value === "string" ? value : "")),
+      tap(() => this.formControl.updateValueAndValidity()),
+    );
 
-            const spinnerDelayed$ = timer(LOADING_INDICATOR_DELAY_MS).pipe(
-              map(() => [...immediateResults, LOADING_INDICATOR]),
-              takeUntil(remoteCallCompleted$),
-            );
-            return concat(
-              of(immediateResults),
-              spinnerDelayed$,
-              remoteCallCompleted$,
-            );
-          } else {
-            return of(localResults);
+    query$
+      .pipe(
+        takeUntil(this.destroy$),
+        switchMap((query: string) => {
+          this.paginationState = { page: 0, totalPages: 1, isLoading: false };
+          const localResults = this._filter(query);
+          if (query?.length < (this.props.externalOptions.threshold ?? 3)) {
+            return of({ isLoading: false, options: localResults });
           }
+
+          const pageTrigger = new BehaviorSubject<number>(0);
+          this.loadMore
+            .pipe(
+              takeUntil(query$.pipe(skip(1))),
+              filter(
+                () =>
+                  !this.paginationState.isLoading &&
+                  this.paginationState.page <
+                    this.paginationState.totalPages - 1,
+              ),
+              map(() => this.paginationState.page + 1),
+            )
+            .subscribe(pageTrigger);
+
+          return pageTrigger.pipe(
+            distinctUntilChanged(),
+            concatMap((pageToFetch) => {
+              const remoteCall$ = timer(pageToFetch === 0 ? 50 : 0).pipe(
+                tap(() => {
+                  this.paginationState.isLoading = true;
+                }),
+                switchMap(() =>
+                  this.props.externalOptions.fetchCodelist(query, pageToFetch),
+                ),
+                catchError(() => of(EMPTY_PAGED_SEARCH_RESULT)),
+                map((remoteResults: PagedSearchResult) => {
+                  this.paginationState = {
+                    page: remoteResults.page,
+                    totalPages: remoteResults.totalPages,
+                    isLoading: false,
+                  };
+
+                  const newExternalResults = remoteResults.results.map(
+                    (label) => new SelectOption(null, label),
+                  );
+                  this.externalResultsCache.updateCache(newExternalResults);
+
+                  const allCachedForQuery =
+                    this.externalResultsCache.filter(query);
+
+                  return {
+                    isLoading: false,
+                    options: this.props.externalOptions.deduplicate(
+                      localResults,
+                      allCachedForQuery,
+                    ),
+                  };
+                }),
+              );
+
+              if (pageToFetch === 0) {
+                const cachedFilteredResults =
+                  this.externalResultsCache.filter(query);
+                const immediateResults = this.props.externalOptions.deduplicate(
+                  localResults,
+                  cachedFilteredResults,
+                );
+
+                const spinnerDelayed$ = timer(LOADING_INDICATOR_DELAY_MS).pipe(
+                  map(() => ({
+                    isLoading: true,
+                    options: [...immediateResults, LOADING_INDICATOR],
+                  })),
+                  takeUntil(remoteCall$),
+                );
+
+                return concat(
+                  of({ isLoading: false, options: immediateResults }),
+                  spinnerDelayed$,
+                  remoteCall$,
+                );
+              } else {
+                return concat(of({ isLoading: true }), remoteCall$);
+              }
+            }),
+          );
         }),
+        scan(
+          (acc: { options: SelectOption[] }, val: any) => {
+            if (val.isLoading) {
+              if (val.options) {
+                return { options: val.options };
+              } else {
+                const currentOptions = acc.options.filter(
+                  (o) => o !== LOADING_INDICATOR,
+                );
+                return { options: [...currentOptions, LOADING_INDICATOR] };
+              }
+            } else {
+              return { options: val.options };
+            }
+          },
+          { options: [] },
+        ),
+        map((state) => state.options),
         tap((value) => this._markSelected(value)),
       )
       .subscribe((value) => this.filteredOptions.set(value));
@@ -706,5 +786,19 @@ export class RepeatListComponent
         .replace(/,([^,]*)$/, " und$1");
     }
     return formattedDuplicates;
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  onScroll() {
+    if (
+      !this.paginationState.isLoading &&
+      this.paginationState.page < this.paginationState.totalPages - 1
+    ) {
+      this.loadMore.next();
+    }
   }
 }

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
@@ -56,6 +56,7 @@ import {
   timer,
 } from "rxjs";
 import {
+  ExternalCodelistResult,
   SelectOption,
   SelectOptionUi,
 } from "../../../services/codelist/codelist.service";
@@ -140,7 +141,10 @@ export interface RepeatListProps extends FormlyFieldProps {
   convert: (item: any) => string;
   hideInputField: boolean;
   externalOptions?: {
-    fetchCodelist: (query: string, page: number) => Observable<any[]>;
+    fetchCodelist: (
+      query: string,
+      page: number,
+    ) => Observable<ExternalCodelistResult>;
     deduplicate: (
       options: SelectOption[],
       externalOptions: SelectOption[],
@@ -326,10 +330,10 @@ export class RepeatListComponent
                     .fetchCodelist(query, page)
                     .pipe(
                       catchError(() => of([])),
-                      map((remoteResults) =>
+                      map((remoteResults: ExternalCodelistResult) =>
                         this.props.externalOptions.deduplicate(
                           localResults,
-                          remoteResults,
+                          remoteResults.options,
                         ),
                       ),
                     )

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
@@ -36,14 +36,16 @@ import {
   MatAutocompleteTrigger,
 } from "@angular/material/autocomplete";
 import {
+  catchError,
   debounceTime,
   distinctUntilChanged,
   filter,
   map,
   startWith,
+  switchMap,
   tap,
 } from "rxjs/operators";
-import { merge, Observable, Subject, Subscription } from "rxjs";
+import { merge, Observable, of, Subject, Subscription } from "rxjs";
 import {
   SelectOption,
   SelectOptionUi,
@@ -100,7 +102,7 @@ class MyErrorStateMatcher implements ErrorStateMatcher {
   }
 }
 
-interface RepeatListProps extends FormlyFieldProps {
+export interface RepeatListProps extends FormlyFieldProps {
   asSelect: boolean;
   showSearch: boolean;
   restCall: any;
@@ -122,6 +124,7 @@ interface RepeatListProps extends FormlyFieldProps {
   selectLabelField: string | ((item: any) => string);
   convert: (item: any) => string;
   hideInputField: boolean;
+  externalOptionsThreshold?: number;
 }
 
 @UntilDestroy()
@@ -222,7 +225,7 @@ export class RepeatListComponent
           .pipe(untilDestroyed(this))
           .subscribe((value) => this.manualUpdate.next(value));
       }
-    } else if (this.props.restCall) {
+    } else if (this.props.restCall && !this.props.options) {
       this.type.set("search");
       if (!this.props.labelField) this.props.labelField = "label";
       if (!this.props.selectLabelField)
@@ -282,15 +285,47 @@ export class RepeatListComponent
       });
 
     if (this.props.restCall) {
-      this.inputControl.valueChanges
-        .pipe(
-          untilDestroyed(this),
-          startWith(""),
-          debounceTime(300),
-          tap(() => this.formControl.updateValueAndValidity()),
-          filter((query) => query?.length > 1),
-        )
-        .subscribe((query) => this.search(query));
+      if (this.props.options) {
+        this.inputControl.valueChanges
+          .pipe(
+            untilDestroyed(this),
+            startWith(""),
+            debounceTime(50),
+            tap(() => this.formControl.updateValueAndValidity()),
+          )
+          .pipe(
+            switchMap((query: string) => {
+              const localResults = this._filter(query);
+              let remoteCall$: Observable<any[]> = of([]);
+              if (
+                query &&
+                query.length >= (this.props.externalOptionsThreshold ?? 3)
+              ) {
+                remoteCall$ = this.props
+                  .restCall(query)
+                  .pipe(catchError(() => of([])));
+              }
+              return remoteCall$.pipe(
+                map((remoteResults: any[]) => [
+                  ...localResults,
+                  ...remoteResults,
+                ]),
+              );
+            }),
+            tap((value) => this._markSelected(value)), // Mark selected based on combined list
+          )
+          .subscribe((value) => this.filteredOptions.set(value));
+      } else {
+        this.inputControl.valueChanges
+          .pipe(
+            untilDestroyed(this),
+            startWith(""),
+            debounceTime(300),
+            tap(() => this.formControl.updateValueAndValidity()),
+            filter((query) => query?.length > 1),
+          )
+          .subscribe((query) => this.search(query));
+      }
     } else {
       merge(
         this.formControl.valueChanges,
@@ -339,9 +374,12 @@ export class RepeatListComponent
       return;
     }
 
-    const prepared = new SelectOption(option.value, option.label).forBackend(
-      this.props.codelistId,
-    );
+    const prepared =
+      option.value == null
+        ? new SelectOption(null, option.label).forBackend(null)
+        : new SelectOption(option.value, option.label).forBackend(
+            this.props.codelistId,
+          );
     this.formControl.patchValue([...(this.formControl.value || []), prepared]);
     this.props.change?.(this.field, prepared);
 
@@ -415,12 +453,14 @@ export class RepeatListComponent
     value?.forEach((option) => {
       const disabledByDefault = this.initialParameterOptions.find(
         (item) => item.value === option.value,
-      ).disabled;
+      )?.disabled;
       const optionAlreadySelected = this.model?.[
         this.field.key as string
       ]?.some(
         (modelOption: any) =>
-          modelOption && (modelOption.key ?? modelOption) === option.value,
+          modelOption &&
+          ((modelOption.key ?? modelOption) === option.value ||
+            modelOption.value === option.label),
       );
       option.disabled = disabledByDefault || optionAlreadySelected;
     });

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
@@ -313,83 +313,95 @@ export class RepeatListComponent
       });
 
     if (this.props.externalOptions) {
-      this.inputControl.valueChanges
-        .pipe(
-          untilDestroyed(this),
-          startWith(""),
-          debounceTime(50),
-          tap(() => this.formControl.updateValueAndValidity()),
-          switchMap((query: string) => {
-            const localResults = this._filter(query);
-            if (
-              query &&
-              query.length >= (this.props.externalOptions.threshold ?? 3)
-            ) {
-              const page = 0;
-              const remoteCallCompleted$ = new Observable<SelectOptionUi[]>(
-                (subscriber) => {
-                  const subscription = this.props.externalOptions
-                    .fetchCodelist(query, page)
-                    .pipe(
-                      catchError(() => of([])),
-                      map((remoteResults: PagedSearchResult) =>
-                        this.props.externalOptions.deduplicate(
-                          localResults,
-                          remoteResults.results.map(
-                            (label) => new SelectOption(null, label),
-                          ),
+      this.handleExternalOptions();
+    } else if (this.props.restCall) {
+      this.handleRestCall();
+    } else {
+      this.handleOptions();
+    }
+  }
+
+  handleExternalOptions() {
+    this.inputControl.valueChanges
+      .pipe(
+        untilDestroyed(this),
+        startWith(""),
+        debounceTime(50),
+        tap(() => this.formControl.updateValueAndValidity()),
+        switchMap((query: string) => {
+          const localResults = this._filter(query);
+          if (
+            query &&
+            query.length >= (this.props.externalOptions.threshold ?? 3)
+          ) {
+            const page = 0;
+            const remoteCallCompleted$ = new Observable<SelectOptionUi[]>(
+              (subscriber) => {
+                const subscription = this.props.externalOptions
+                  .fetchCodelist(query, page)
+                  .pipe(
+                    catchError(() => of([])),
+                    map((remoteResults: PagedSearchResult) =>
+                      this.props.externalOptions.deduplicate(
+                        localResults,
+                        remoteResults.results.map(
+                          (label) => new SelectOption(null, label),
                         ),
                       ),
-                    )
-                    .subscribe(subscriber);
-                  return () => subscription.unsubscribe();
-                },
-              );
+                    ),
+                  )
+                  .subscribe(subscriber);
+                return () => subscription.unsubscribe();
+              },
+            );
 
-              const spinnerDelayed$ = timer(LOADING_INDICATOR_DELAY_MS).pipe(
-                map(() => [...localResults, LOADING_INDICATOR]),
-                takeUntil(remoteCallCompleted$),
-              );
-              return concat(
-                of(localResults),
-                spinnerDelayed$,
-                remoteCallCompleted$,
-              );
-            } else {
-              return of(localResults);
-            }
-          }),
-          tap((value) => this._markSelected(value)),
-        )
-        .subscribe((value) => this.filteredOptions.set(value));
-    } else if (this.props.restCall) {
-      this.inputControl.valueChanges
-        .pipe(
-          untilDestroyed(this),
-          startWith(""),
-          debounceTime(300),
-          tap(() => this.formControl.updateValueAndValidity()),
-          filter((query) => query?.length > 1),
-        )
-        .subscribe((query) => this.search(query));
-    } else {
-      merge(
-        this.formControl.valueChanges,
-        this.inputControl.valueChanges.pipe(
-          tap(() => this.formControl.updateValueAndValidity()),
-        ),
-        this.manualUpdate.asObservable(),
+            const spinnerDelayed$ = timer(LOADING_INDICATOR_DELAY_MS).pipe(
+              map(() => [...localResults, LOADING_INDICATOR]),
+              takeUntil(remoteCallCompleted$),
+            );
+            return concat(
+              of(localResults),
+              spinnerDelayed$,
+              remoteCallCompleted$,
+            );
+          } else {
+            return of(localResults);
+          }
+        }),
+        tap((value) => this._markSelected(value)),
       )
-        .pipe(
-          untilDestroyed(this),
-          startWith(""),
-          debounceTime(0),
-          filter((value) => value !== undefined && value !== null),
-          map((value) => this._filter(value)),
-          tap((value) => this._markSelected(value)),
-        )
-        .subscribe((value) => this.filteredOptions.set(value));
-    }
+      .subscribe((value) => this.filteredOptions.set(value));
+  }
+
+  handleRestCall() {
+    this.inputControl.valueChanges
+      .pipe(
+        untilDestroyed(this),
+        startWith(""),
+        debounceTime(300),
+        tap(() => this.formControl.updateValueAndValidity()),
+        filter((query) => query?.length > 1),
+      )
+      .subscribe((query) => this.search(query));
+  }
+
+  handleOptions() {
+    merge(
+      this.formControl.valueChanges,
+      this.inputControl.valueChanges.pipe(
+        tap(() => this.formControl.updateValueAndValidity()),
+      ),
+      this.manualUpdate.asObservable(),
+    )
+      .pipe(
+        untilDestroyed(this),
+        startWith(""),
+        debounceTime(0),
+        filter((value) => value !== undefined && value !== null),
+        map((value) => this._filter(value)),
+        tap((value) => this._markSelected(value)),
+      )
+      .subscribe((value) => this.filteredOptions.set(value));
   }
 
   addToList(option: SelectOptionUi) {

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
@@ -124,7 +124,13 @@ export interface RepeatListProps extends FormlyFieldProps {
   selectLabelField: string | ((item: any) => string);
   convert: (item: any) => string;
   hideInputField: boolean;
-  externalOptionsThreshold?: number;
+  externalOptions?: {
+    deduplicate: (
+      options: SelectOption[],
+      externalOptions: SelectOption[],
+    ) => SelectOption[];
+    threshold?: number;
+  };
 }
 
 @UntilDestroy()
@@ -299,24 +305,19 @@ export class RepeatListComponent
               let remoteCall$: Observable<any[]> = of([]);
               if (
                 query &&
-                query.length >= (this.props.externalOptionsThreshold ?? 3)
+                query.length >= (this.props.externalOptions.threshold ?? 3)
               ) {
                 remoteCall$ = this.props
                   .restCall(query)
                   .pipe(catchError(() => of([])));
               }
               return remoteCall$.pipe(
-                map((remoteResults: any[]) => {
-                  const localLabels = localResults.map((r) =>
-                    r.label.toLowerCase(),
-                  );
-                  return [
-                    ...localResults,
-                    ...remoteResults.filter(
-                      (r) => !localLabels.includes(r.label.toLowerCase()),
-                    ),
-                  ];
-                }),
+                map((remoteResults) =>
+                  this.props.externalOptions.deduplicate(
+                    localResults,
+                    remoteResults,
+                  ),
+                ),
               );
             }),
             tap((value) => this._markSelected(value)), // Mark selected based on combined list

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
@@ -104,6 +104,7 @@ import {
   BackendOption,
   PagedSearchResult,
 } from "../../../store/codelist/codelist.model";
+import { ExternalResultsCache } from "./external-result-cache";
 
 class MyErrorStateMatcher implements ErrorStateMatcher {
   constructor(private component: RepeatListComponent) {}
@@ -119,6 +120,7 @@ const LOADING_INDICATOR: SelectOption = new SelectOption(
   "Lädt externe Codelist-Einträge...",
 );
 const LOADING_INDICATOR_DELAY_MS = 200;
+const EMPTY_PAGED_SEARCH_RESULT = { page: 0, totalPages: 0, results: [] };
 
 export interface RepeatListProps extends FormlyFieldProps {
   asSelect: boolean;
@@ -196,6 +198,7 @@ export class RepeatListComponent
   implements OnInit
 {
   private codelistStore = inject(CodelistStore);
+  private externalResultsCache: ExternalResultsCache;
   readonly autoCompleteEl = viewChild("repeatListInput", { read: ElementRef });
   readonly autoComplete = viewChild(MatAutocompleteTrigger);
   readonly selector = viewChild(MatSelect);
@@ -313,6 +316,9 @@ export class RepeatListComponent
       });
 
     if (this.props.externalOptions) {
+      this.externalResultsCache = new ExternalResultsCache(
+        this.props.externalOptions.deduplicate,
+      );
       this.handleExternalOptions();
     } else if (this.props.restCall) {
       this.handleRestCall();
@@ -326,41 +332,40 @@ export class RepeatListComponent
       .pipe(
         untilDestroyed(this),
         startWith(""),
-        debounceTime(50),
         tap(() => this.formControl.updateValueAndValidity()),
         switchMap((query: string) => {
           const localResults = this._filter(query);
-          if (
-            query &&
-            query.length >= (this.props.externalOptions.threshold ?? 3)
-          ) {
-            const page = 0;
-            const remoteCallCompleted$ = new Observable<SelectOptionUi[]>(
-              (subscriber) => {
-                const subscription = this.props.externalOptions
-                  .fetchCodelist(query, page)
-                  .pipe(
-                    catchError(() => of([])),
-                    map((remoteResults: PagedSearchResult) =>
-                      this.props.externalOptions.deduplicate(
-                        localResults,
-                        remoteResults.results.map(
-                          (label) => new SelectOption(null, label),
-                        ),
-                      ),
-                    ),
-                  )
-                  .subscribe(subscriber);
-                return () => subscription.unsubscribe();
-              },
+          if (query?.length >= (this.props.externalOptions.threshold ?? 3)) {
+            const cachedFilteredResults =
+              this.externalResultsCache.filter(query);
+            let immediateResults = this.props.externalOptions.deduplicate(
+              localResults,
+              cachedFilteredResults,
+            );
+            // the timer before fetching a codelist from the backend is a simulated debounce, to prevent intermittant requests while a user is still typing
+            const remoteCallCompleted$ = timer(50).pipe(
+              switchMap(() =>
+                this.props.externalOptions.fetchCodelist(query, 0),
+              ),
+              catchError(() => of(EMPTY_PAGED_SEARCH_RESULT)),
+              map((remoteResults: PagedSearchResult) => {
+                const newExternalResults = remoteResults.results.map(
+                  (label) => new SelectOption(null, label),
+                );
+                this.externalResultsCache.updateCache(newExternalResults);
+                return this.props.externalOptions.deduplicate(
+                  localResults,
+                  newExternalResults,
+                );
+              }),
             );
 
             const spinnerDelayed$ = timer(LOADING_INDICATOR_DELAY_MS).pipe(
-              map(() => [...localResults, LOADING_INDICATOR]),
+              map(() => [...immediateResults, LOADING_INDICATOR]),
               takeUntil(remoteCallCompleted$),
             );
             return concat(
-              of(localResults),
+              of(immediateResults),
               spinnerDelayed$,
               remoteCallCompleted$,
             );

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
@@ -43,9 +43,18 @@ import {
   map,
   startWith,
   switchMap,
+  takeUntil,
   tap,
 } from "rxjs/operators";
-import { concat, merge, Observable, of, Subject, Subscription } from "rxjs";
+import {
+  concat,
+  merge,
+  Observable,
+  of,
+  Subject,
+  Subscription,
+  timer,
+} from "rxjs";
 import {
   SelectOption,
   SelectOptionUi,
@@ -106,6 +115,7 @@ const LOADING_INDICATOR: SelectOption = new SelectOption(
   "_LOADING_SPINNER_",
   "Lädt externe Codelist-Einträge...",
 );
+const LOADING_INDICATOR_DELAY_MS = 200;
 
 export interface RepeatListProps extends FormlyFieldProps {
   asSelect: boolean;
@@ -309,18 +319,34 @@ export class RepeatListComponent
               query &&
               query.length >= (this.props.externalOptions.threshold ?? 3)
             ) {
-              const initialStream = of([...localResults, LOADING_INDICATOR]);
-              const remoteCall$: Observable<SelectOptionUi[]> =
-                this.props.externalOptions.fetchCodelist(query, 0).pipe(
-                  catchError(() => of([])),
-                  map((remoteResults) =>
-                    this.props.externalOptions.deduplicate(
-                      localResults,
-                      remoteResults,
-                    ),
-                  ),
-                );
-              return concat(initialStream, remoteCall$);
+              const page = 0;
+              const remoteCallCompleted$ = new Observable<SelectOptionUi[]>(
+                (subscriber) => {
+                  const subscription = this.props.externalOptions
+                    .fetchCodelist(query, page)
+                    .pipe(
+                      catchError(() => of([])),
+                      map((remoteResults) =>
+                        this.props.externalOptions.deduplicate(
+                          localResults,
+                          remoteResults,
+                        ),
+                      ),
+                    )
+                    .subscribe(subscriber);
+                  return () => subscription.unsubscribe();
+                },
+              );
+
+              const spinnerDelayed$ = timer(LOADING_INDICATOR_DELAY_MS).pipe(
+                map(() => [...localResults, LOADING_INDICATOR]),
+                takeUntil(remoteCallCompleted$),
+              );
+              return concat(
+                of(localResults),
+                spinnerDelayed$,
+                remoteCallCompleted$,
+              );
             } else {
               return of(localResults);
             }

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
@@ -56,7 +56,6 @@ import {
   timer,
 } from "rxjs";
 import {
-  ExternalCodelistResult,
   SelectOption,
   SelectOptionUi,
 } from "../../../services/codelist/codelist.service";
@@ -101,7 +100,10 @@ import { SearchInputComponent } from "../../../shared/search-input/search-input.
 import { MatProgressSpinner } from "@angular/material/progress-spinner";
 import { FieldToAiraLabelledbyPipe } from "../../../directives/fieldToAiraLabelledby.pipe";
 import { CodelistStore } from "../../../store/codelist/codelist.store";
-import { BackendOption } from "../../../store/codelist/codelist.model";
+import {
+  BackendOption,
+  PagedSearchResult,
+} from "../../../store/codelist/codelist.model";
 
 class MyErrorStateMatcher implements ErrorStateMatcher {
   constructor(private component: RepeatListComponent) {}
@@ -144,7 +146,7 @@ export interface RepeatListProps extends FormlyFieldProps {
     fetchCodelist: (
       query: string,
       page: number,
-    ) => Observable<ExternalCodelistResult>;
+    ) => Observable<PagedSearchResult>;
     deduplicate: (
       options: SelectOption[],
       externalOptions: SelectOption[],
@@ -330,10 +332,12 @@ export class RepeatListComponent
                     .fetchCodelist(query, page)
                     .pipe(
                       catchError(() => of([])),
-                      map((remoteResults: ExternalCodelistResult) =>
+                      map((remoteResults: PagedSearchResult) =>
                         this.props.externalOptions.deduplicate(
                           localResults,
-                          remoteResults.options,
+                          remoteResults.results.map(
+                            (label) => new SelectOption(null, label),
+                          ),
                         ),
                       ),
                     )

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
@@ -19,7 +19,7 @@
  */
 import {
   Component,
-  ElementRef,
+  DestroyRef,
   inject,
   OnInit,
   signal,
@@ -36,28 +36,22 @@ import {
   MatAutocompleteTrigger,
 } from "@angular/material/autocomplete";
 import {
-  catchError,
   debounceTime,
   distinctUntilChanged,
   filter,
   map,
-  scan,
-  skip,
   startWith,
   switchMap,
-  takeUntil,
   tap,
 } from "rxjs/operators";
 import {
   BehaviorSubject,
-  concat,
-  concatMap,
+  combineLatest,
   merge,
   Observable,
   of,
   Subject,
   Subscription,
-  timer,
 } from "rxjs";
 import {
   SelectOption,
@@ -110,6 +104,7 @@ import {
 } from "../../../store/codelist/codelist.model";
 import { ExternalResultsCache } from "./external-result-cache";
 import { OptionsScrollDirective } from "./options-scroll.directive";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 
 class MyErrorStateMatcher implements ErrorStateMatcher {
   constructor(private component: RepeatListComponent) {}
@@ -119,13 +114,6 @@ class MyErrorStateMatcher implements ErrorStateMatcher {
     else return false;
   }
 }
-
-const LOADING_INDICATOR: SelectOption = new SelectOption(
-  "_LOADING_SPINNER_",
-  "Lädt externe Codelist-Einträge...",
-);
-const LOADING_INDICATOR_DELAY_MS = 200;
-const EMPTY_PAGED_SEARCH_RESULT = { page: 0, totalPages: 0, results: [] };
 
 export interface RepeatListProps extends FormlyFieldProps {
   asSelect: boolean;
@@ -161,6 +149,8 @@ export interface RepeatListProps extends FormlyFieldProps {
     threshold?: number;
   };
 }
+
+type PaginationState = { page: number; totalPages: number; isLoading: boolean };
 
 @UntilDestroy()
 @Component({
@@ -204,18 +194,17 @@ export class RepeatListComponent
   implements OnInit
 {
   private codelistStore = inject(CodelistStore);
+  private destroyRef = inject(DestroyRef);
   private externalResultsCache: ExternalResultsCache;
-  readonly autoCompleteEl = viewChild("repeatListInput", { read: ElementRef });
   readonly autoComplete = viewChild(MatAutocompleteTrigger);
   readonly selector = viewChild(MatSelect);
 
-  private destroy$ = new Subject<void>();
-  private loadMore = new Subject<void>();
-  private paginationState = {
+  paginationState = {
     page: 0,
     totalPages: 1,
     isLoading: false,
   };
+  private loadMore = new BehaviorSubject<PaginationState>(this.paginationState);
 
   onItemClick: (id: number) => void = () => {};
 
@@ -341,124 +330,83 @@ export class RepeatListComponent
     }
   }
 
-  handleExternalOptions() {
+  private handleExternalOptions() {
     const query$ = this.inputControl.valueChanges.pipe(
       startWith(this.inputControl.value),
       map((value) => (typeof value === "string" ? value : "")),
       tap(() => this.formControl.updateValueAndValidity()),
+      tap(() =>
+        this.loadMore.next({ page: 0, totalPages: 1, isLoading: false }),
+      ),
     );
 
-    query$
+    combineLatest([query$, this.loadMore])
       .pipe(
-        takeUntil(this.destroy$),
-        switchMap((query: string) => {
-          this.paginationState = { page: 0, totalPages: 1, isLoading: false };
-          const localResults = this._filter(query);
-          if (query?.length < (this.props.externalOptions.threshold ?? 3)) {
-            return of({ isLoading: false, options: localResults });
-          }
+        takeUntilDestroyed(this.destroyRef),
+        switchMap((event) => this.fetchPagedCodelistsWhenThreshold(event)),
+        map(
+          (result: {
+            query: string;
+            remoteResults: PagedSearchResult;
+            options: SelectOptionUi[];
+          }) => {
+            if (result.options) return result.options;
 
-          const pageTrigger = new BehaviorSubject<number>(0);
-          this.loadMore
-            .pipe(
-              takeUntil(query$.pipe(skip(1))),
-              filter(
-                () =>
-                  !this.paginationState.isLoading &&
-                  this.paginationState.page <
-                    this.paginationState.totalPages - 1,
-              ),
-              map(() => this.paginationState.page + 1),
-            )
-            .subscribe(pageTrigger);
+            this.paginationState = {
+              page: result.remoteResults.page,
+              totalPages: result.remoteResults.totalPages,
+              isLoading: false,
+            };
 
-          return pageTrigger.pipe(
-            distinctUntilChanged(),
-            concatMap((pageToFetch) => {
-              const remoteCall$ = timer(pageToFetch === 0 ? 50 : 0).pipe(
-                tap(() => {
-                  this.paginationState.isLoading = true;
-                }),
-                switchMap(() =>
-                  this.props.externalOptions.fetchCodelist(query, pageToFetch),
-                ),
-                catchError(() => of(EMPTY_PAGED_SEARCH_RESULT)),
-                map((remoteResults: PagedSearchResult) => {
-                  this.paginationState = {
-                    page: remoteResults.page,
-                    totalPages: remoteResults.totalPages,
-                    isLoading: false,
-                  };
-
-                  const newExternalResults = remoteResults.results.map(
-                    (label) => new SelectOption(null, label),
-                  );
-                  this.externalResultsCache.updateCache(newExternalResults);
-
-                  const allCachedForQuery =
-                    this.externalResultsCache.filter(query);
-
-                  return {
-                    isLoading: false,
-                    options: this.props.externalOptions.deduplicate(
-                      localResults,
-                      allCachedForQuery,
-                    ),
-                  };
-                }),
-              );
-
-              if (pageToFetch === 0) {
-                const cachedFilteredResults =
-                  this.externalResultsCache.filter(query);
-                const immediateResults = this.props.externalOptions.deduplicate(
-                  localResults,
-                  cachedFilteredResults,
-                );
-
-                const spinnerDelayed$ = timer(LOADING_INDICATOR_DELAY_MS).pipe(
-                  map(() => ({
-                    isLoading: true,
-                    options: [...immediateResults, LOADING_INDICATOR],
-                  })),
-                  takeUntil(remoteCall$),
-                );
-
-                return concat(
-                  of({ isLoading: false, options: immediateResults }),
-                  spinnerDelayed$,
-                  remoteCall$,
-                );
-              } else {
-                return concat(of({ isLoading: true }), remoteCall$);
-              }
-            }),
-          );
-        }),
-        scan(
-          (acc: { options: SelectOption[] }, val: any) => {
-            if (val.isLoading) {
-              if (val.options) {
-                return { options: val.options };
-              } else {
-                const currentOptions = acc.options.filter(
-                  (o) => o !== LOADING_INDICATOR,
-                );
-                return { options: [...currentOptions, LOADING_INDICATOR] };
-              }
-            } else {
-              return { options: val.options };
-            }
+            return this.mapExternalCodelistsToOptions(result);
           },
-          { options: [] },
         ),
-        map((state) => state.options),
         tap((value) => this._markSelected(value)),
       )
       .subscribe((value) => this.filteredOptions.set(value));
   }
 
-  handleRestCall() {
+  private mapExternalCodelistsToOptions(result: {
+    query: string;
+    remoteResults: PagedSearchResult;
+    options: SelectOptionUi[];
+  }) {
+    const newExternalResults = result.remoteResults.results.map(
+      (label) => new SelectOption(null, label),
+    );
+    this.externalResultsCache.updateCache(newExternalResults);
+
+    const allCachedForQuery = this.externalResultsCache.filter(result.query);
+
+    return this.props.externalOptions.deduplicate(
+      this._filter(result.query),
+      allCachedForQuery,
+    );
+  }
+
+  private fetchPagedCodelistsWhenThreshold<A>(event: A) {
+    const query = event[0];
+    const pagination = event[1];
+    this.paginationState.isLoading = false;
+    const localResults = this._filter(query);
+    const cachedFilteredResults = this.externalResultsCache.filter(query);
+    const immediateResults = this.props.externalOptions.deduplicate(
+      localResults,
+      cachedFilteredResults,
+    );
+    if (query?.length < (this.props.externalOptions.threshold ?? 3)) {
+      return of({ options: immediateResults });
+    }
+
+    this.filteredOptions.set(immediateResults);
+
+    this.paginationState.isLoading = true;
+    return this.props.externalOptions
+      .fetchCodelist(query, pagination.page)
+      .pipe(map((results) => ({ query, remoteResults: results })));
+  }
+
+  private handleRestCall() {
     this.inputControl.valueChanges
       .pipe(
         untilDestroyed(this),
@@ -470,7 +418,7 @@ export class RepeatListComponent
       .subscribe((query) => this.search(query));
   }
 
-  handleOptions() {
+  private handleOptions() {
     merge(
       this.formControl.valueChanges,
       this.inputControl.valueChanges.pipe(
@@ -788,17 +736,14 @@ export class RepeatListComponent
     return formattedDuplicates;
   }
 
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
-
   onScroll() {
+    console.log(".");
     if (
       !this.paginationState.isLoading &&
       this.paginationState.page < this.paginationState.totalPages - 1
     ) {
-      this.loadMore.next();
+      this.paginationState.page = this.paginationState.page + 1;
+      this.loadMore.next(this.paginationState);
     }
   }
 }

--- a/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
+++ b/frontend/src/app/formly/types/repeat-list/repeat-list.component.ts
@@ -89,6 +89,7 @@ import { SearchInputComponent } from "../../../shared/search-input/search-input.
 import { MatProgressSpinner } from "@angular/material/progress-spinner";
 import { FieldToAiraLabelledbyPipe } from "../../../directives/fieldToAiraLabelledby.pipe";
 import { CodelistStore } from "../../../store/codelist/codelist.store";
+import { BackendOption } from "../../../store/codelist/codelist.model";
 
 class MyErrorStateMatcher implements ErrorStateMatcher {
   constructor(private component: RepeatListComponent) {}
@@ -181,7 +182,7 @@ export class RepeatListComponent
     };
   };
 
-  items = signal<any[]>([]);
+  items = signal<BackendOption[]>([]);
 
   filteredOptions = signal<SelectOptionUi[]>([]);
   parameterOptions: SelectOptionUi[];

--- a/frontend/src/app/services/codelist/codelist-data.service.ts
+++ b/frontend/src/app/services/codelist/codelist-data.service.ts
@@ -80,6 +80,12 @@ export class CodelistDataService {
     );
   }
 
+  getExternalCodelist(id: string, filter: string) {
+    return this.http.get<string[]>(
+      this.configuration.backendUrl + "codelist/external/" + id + "/" + filter,
+    );
+  }
+
   syncCodelistValues(migrate: boolean) {
     return this.http.post<void>(
       this.configuration.backendUrl +

--- a/frontend/src/app/services/codelist/codelist-data.service.ts
+++ b/frontend/src/app/services/codelist/codelist-data.service.ts
@@ -20,7 +20,10 @@
 import { HttpClient } from "@angular/common/http";
 import { ConfigService, Configuration } from "../config/config.service";
 import { Injectable } from "@angular/core";
-import { CodelistBackend } from "../../store/codelist/codelist.model";
+import {
+  CodelistBackend,
+  PagedSearchResult,
+} from "../../store/codelist/codelist.model";
 
 @Injectable({
   providedIn: "root",
@@ -80,9 +83,12 @@ export class CodelistDataService {
     );
   }
 
-  getExternalCodelist(id: string, filter: string) {
-    return this.http.get<string[]>(
+  getExternalCodelist(id: string, filter: string, page: number = 0) {
+    return this.http.get<PagedSearchResult>(
       this.configuration.backendUrl + "codelist/external/" + id + "/" + filter,
+      {
+        params: { page: page },
+      },
     );
   }
 

--- a/frontend/src/app/services/codelist/codelist.service.ts
+++ b/frontend/src/app/services/codelist/codelist.service.ts
@@ -328,11 +328,14 @@ export class CodelistService {
   observeExternal(
     codelistId: string,
     filter: string,
+    page: number,
   ): Observable<SelectOptionUi[]> {
     return this.dataService
-      .getExternalCodelist(codelistId, filter)
+      .getExternalCodelist(codelistId, filter, page)
       .pipe(
-        map((labels) => labels.map((label) => new SelectOption(null, label))),
+        map((pagedResult) =>
+          pagedResult.results.map((label) => new SelectOption(null, label)),
+        ),
       );
   }
 

--- a/frontend/src/app/services/codelist/codelist.service.ts
+++ b/frontend/src/app/services/codelist/codelist.service.ts
@@ -25,6 +25,7 @@ import {
   CodelistBackend,
   CodelistEntry,
   CodelistEntryBackend,
+  PagedSearchResult,
 } from "../../store/codelist/codelist.model";
 import {
   bufferTime,
@@ -68,12 +69,6 @@ export class SelectOption {
 export interface SelectOptionUi extends SelectOption {
   disabled?: boolean;
   sortkey?: CodelistSort;
-}
-
-export interface ExternalCodelistResult {
-  options: SelectOptionUi[];
-  page: number;
-  totalPages: number;
 }
 
 export type CodelistSort =
@@ -335,16 +330,8 @@ export class CodelistService {
     codelistId: string,
     filter: string,
     page: number,
-  ): Observable<ExternalCodelistResult> {
-    return this.dataService.getExternalCodelist(codelistId, filter, page).pipe(
-      map((pagedResult) => ({
-        options: pagedResult.results.map(
-          (label) => new SelectOption(null, label),
-        ),
-        page: pagedResult.page,
-        totalPages: pagedResult.totalPages,
-      })),
-    );
+  ): Observable<PagedSearchResult> {
+    return this.dataService.getExternalCodelist(codelistId, filter, page);
   }
 
   observeRaw(codelistId: string): Observable<Codelist> {

--- a/frontend/src/app/services/codelist/codelist.service.ts
+++ b/frontend/src/app/services/codelist/codelist.service.ts
@@ -325,6 +325,17 @@ export class CodelistService {
     );
   }
 
+  observeExternal(
+    codelistId: string,
+    filter: string,
+  ): Observable<SelectOptionUi[]> {
+    return this.dataService
+      .getExternalCodelist(codelistId, filter)
+      .pipe(
+        map((labels) => labels.map((label) => new SelectOption(null, label))),
+      );
+  }
+
   observeRaw(codelistId: string): Observable<Codelist> {
     const alreadyInQueue = this.queue.some((item) => item === codelistId);
     const alreadyInStore = this.store.entityMap()[codelistId];

--- a/frontend/src/app/services/codelist/codelist.service.ts
+++ b/frontend/src/app/services/codelist/codelist.service.ts
@@ -70,6 +70,12 @@ export interface SelectOptionUi extends SelectOption {
   sortkey?: CodelistSort;
 }
 
+export interface ExternalCodelistResult {
+  options: SelectOptionUi[];
+  page: number;
+  totalPages: number;
+}
+
 export type CodelistSort =
   | "NO_SORT"
   | "value"
@@ -329,14 +335,16 @@ export class CodelistService {
     codelistId: string,
     filter: string,
     page: number,
-  ): Observable<SelectOptionUi[]> {
-    return this.dataService
-      .getExternalCodelist(codelistId, filter, page)
-      .pipe(
-        map((pagedResult) =>
-          pagedResult.results.map((label) => new SelectOption(null, label)),
+  ): Observable<ExternalCodelistResult> {
+    return this.dataService.getExternalCodelist(codelistId, filter, page).pipe(
+      map((pagedResult) => ({
+        options: pagedResult.results.map(
+          (label) => new SelectOption(null, label),
         ),
-      );
+        page: pagedResult.page,
+        totalPages: pagedResult.totalPages,
+      })),
+    );
   }
 
   observeRaw(codelistId: string): Observable<Codelist> {

--- a/frontend/src/app/store/codelist/codelist.model.ts
+++ b/frontend/src/app/store/codelist/codelist.model.ts
@@ -54,3 +54,9 @@ export interface BackendOption {
   value: string;
   _codelistId: string;
 }
+
+export interface PagedSearchResult {
+  page: number;
+  totalPages: number;
+  results: string[];
+}

--- a/frontend/src/profiles/base.doctype.ts
+++ b/frontend/src/profiles/base.doctype.ts
@@ -123,8 +123,9 @@ export abstract class BaseDoctype extends FormFieldHelper implements Doctype {
   getExternalCodelistForSelect(
     codelistId: string,
     filter: string,
+    page: number,
   ): Observable<SelectOptionUi[]> {
-    return this.codelistService.observeExternal(codelistId, filter);
+    return this.codelistService.observeExternal(codelistId, filter, page);
   }
 
   async init(help: string[]): Promise<void> {

--- a/frontend/src/profiles/base.doctype.ts
+++ b/frontend/src/profiles/base.doctype.ts
@@ -120,6 +120,13 @@ export abstract class BaseDoctype extends FormFieldHelper implements Doctype {
     return this.codelistService.observe(codelistId, sortBy);
   }
 
+  getExternalCodelistForSelect(
+    codelistId: string,
+    filter: string,
+  ): Observable<SelectOptionUi[]> {
+    return this.codelistService.observeExternal(codelistId, filter);
+  }
+
   async init(help: string[]): Promise<void> {
     this.helpIds = help;
     await this.isInitialized();

--- a/frontend/src/profiles/base.doctype.ts
+++ b/frontend/src/profiles/base.doctype.ts
@@ -23,6 +23,7 @@ import { Observable } from "rxjs";
 import {
   CodelistService,
   CodelistSort,
+  ExternalCodelistResult,
   SelectOption,
   SelectOptionUi,
 } from "../app/services/codelist/codelist.service";
@@ -124,7 +125,7 @@ export abstract class BaseDoctype extends FormFieldHelper implements Doctype {
     codelistId: string,
     filter: string,
     page: number,
-  ): Observable<SelectOptionUi[]> {
+  ): Observable<ExternalCodelistResult> {
     return this.codelistService.observeExternal(codelistId, filter, page);
   }
 

--- a/frontend/src/profiles/base.doctype.ts
+++ b/frontend/src/profiles/base.doctype.ts
@@ -23,7 +23,6 @@ import { Observable } from "rxjs";
 import {
   CodelistService,
   CodelistSort,
-  ExternalCodelistResult,
   SelectOption,
   SelectOptionUi,
 } from "../app/services/codelist/codelist.service";
@@ -34,7 +33,10 @@ import { inject } from "@angular/core";
 import { FormStateService } from "../app/+form/form-state.service";
 import { CodelistStore } from "../app/store/codelist/codelist.store";
 import { toObservable } from "@angular/core/rxjs-interop";
-import { Codelist } from "../app/store/codelist/codelist.model";
+import {
+  Codelist,
+  PagedSearchResult,
+} from "../app/store/codelist/codelist.model";
 
 export abstract class BaseDoctype extends FormFieldHelper implements Doctype {
   protected codelistService = inject(CodelistService);
@@ -125,7 +127,7 @@ export abstract class BaseDoctype extends FormFieldHelper implements Doctype {
     codelistId: string,
     filter: string,
     page: number,
-  ): Observable<ExternalCodelistResult> {
+  ): Observable<PagedSearchResult> {
     return this.codelistService.observeExternal(codelistId, filter, page);
   }
 

--- a/frontend/src/profiles/form-field-helper.ts
+++ b/frontend/src/profiles/form-field-helper.ts
@@ -124,7 +124,7 @@ export interface RepeatListOptions extends Options {
   fieldGroupClassName?: string; // TODO: move up
   options?: Partial<SelectOptionUi>[] | Observable<Partial<SelectOptionUi>[]>;
   externalOptions?: {
-    codelistCall: (query: string) => Observable<any[]>;
+    fetchCodelist: (query: string, page: number) => Observable<any[]>;
     deduplicate: (
       options: SelectOption[],
       externalOptions: SelectOption[],
@@ -447,11 +447,9 @@ export class FormFieldHelper {
       ...options,
       asAutocomplete: true,
       labelField: "value",
-      restCall: options.externalOptions?.codelistCall,
     });
     (repeatList.props as RepeatListProps).externalOptions = {
-      deduplicate: options.externalOptions?.deduplicate,
-      threshold: options.externalOptions?.threshold,
+      ...options.externalOptions,
     };
     return repeatList;
   }

--- a/frontend/src/profiles/form-field-helper.ts
+++ b/frontend/src/profiles/form-field-helper.ts
@@ -19,7 +19,10 @@
  */
 import { FormlyFieldConfig } from "@ngx-formly/core";
 import { Observable } from "rxjs";
-import { SelectOptionUi } from "../app/services/codelist/codelist.service";
+import {
+  SelectOption,
+  SelectOptionUi,
+} from "../app/services/codelist/codelist.service";
 import { HttpClient } from "@angular/common/http";
 import { Component, inject, Signal } from "@angular/core";
 import { TranslocoService } from "@jsverse/transloco";
@@ -120,7 +123,14 @@ export interface RepeatListOptions extends Options {
   showSearch?: boolean;
   fieldGroupClassName?: string; // TODO: move up
   options?: Partial<SelectOptionUi>[] | Observable<Partial<SelectOptionUi>[]>;
-  externalOptionsThreshold?: number;
+  externalOptions?: {
+    codelistCall: (query: string) => Observable<any[]>;
+    deduplicate: (
+      options: SelectOption[],
+      externalOptions: SelectOption[],
+    ) => SelectOption[];
+    threshold?: number;
+  };
   view?: "chip" | "list";
   restCall?: (query: string) => Observable<any[]>;
   labelField?: string;
@@ -432,14 +442,17 @@ export class FormFieldHelper {
     };
   }
 
-  addExtendedRepeatList(id, label, options?: RepeatListOptions) {
+  addExtendedRepeatList(id, label, options: RepeatListOptions) {
     let repeatList = this.addRepeatList(id, label, {
       ...options,
       asAutocomplete: true,
       labelField: "value",
+      restCall: options.externalOptions?.codelistCall,
     });
-    (repeatList.props as RepeatListProps).externalOptionsThreshold =
-      options?.externalOptionsThreshold;
+    (repeatList.props as RepeatListProps).externalOptions = {
+      deduplicate: options.externalOptions?.deduplicate,
+      threshold: options.externalOptions?.threshold,
+    };
     return repeatList;
   }
 

--- a/frontend/src/profiles/form-field-helper.ts
+++ b/frontend/src/profiles/form-field-helper.ts
@@ -29,6 +29,7 @@ import { TableProps } from "../app/formly/types/table/table-type.component";
 import { LongTermFileStorageTreeStore } from "../app/store/tree/long-term-file-storage-tree.store";
 import { DocumentTreeStore } from "../app/store/tree/document-tree.store";
 import { ConfigService } from "../app/services/config/config.service";
+import { RepeatListProps } from "../app/formly/types/repeat-list/repeat-list.component";
 
 export interface FieldConfigPosition {
   fieldConfig: FormlyFieldConfig[];
@@ -119,6 +120,7 @@ export interface RepeatListOptions extends Options {
   showSearch?: boolean;
   fieldGroupClassName?: string; // TODO: move up
   options?: Partial<SelectOptionUi>[] | Observable<Partial<SelectOptionUi>[]>;
+  externalOptionsThreshold?: number;
   view?: "chip" | "list";
   restCall?: (query: string) => Observable<any[]>;
   labelField?: string;
@@ -428,6 +430,17 @@ export class FormFieldHelper {
       expressions: expressions,
       validators: options?.validators,
     };
+  }
+
+  addExtendedRepeatList(id, label, options?: RepeatListOptions) {
+    let repeatList = this.addRepeatList(id, label, {
+      ...options,
+      asAutocomplete: true,
+      labelField: "value",
+    });
+    (repeatList.props as RepeatListProps).externalOptionsThreshold =
+      options?.externalOptionsThreshold;
+    return repeatList;
   }
 
   addRepeatDetailList(

--- a/frontend/src/profiles/form-field-helper.ts
+++ b/frontend/src/profiles/form-field-helper.ts
@@ -20,6 +20,7 @@
 import { FormlyFieldConfig } from "@ngx-formly/core";
 import { Observable } from "rxjs";
 import {
+  ExternalCodelistResult,
   SelectOption,
   SelectOptionUi,
 } from "../app/services/codelist/codelist.service";
@@ -33,6 +34,7 @@ import { LongTermFileStorageTreeStore } from "../app/store/tree/long-term-file-s
 import { DocumentTreeStore } from "../app/store/tree/document-tree.store";
 import { ConfigService } from "../app/services/config/config.service";
 import { RepeatListProps } from "../app/formly/types/repeat-list/repeat-list.component";
+import { PagedSearchResult } from "../app/store/codelist/codelist.model";
 
 export interface FieldConfigPosition {
   fieldConfig: FormlyFieldConfig[];
@@ -124,7 +126,10 @@ export interface RepeatListOptions extends Options {
   fieldGroupClassName?: string; // TODO: move up
   options?: Partial<SelectOptionUi>[] | Observable<Partial<SelectOptionUi>[]>;
   externalOptions?: {
-    fetchCodelist: (query: string, page: number) => Observable<any[]>;
+    fetchCodelist: (
+      query: string,
+      page: number,
+    ) => Observable<ExternalCodelistResult>;
     deduplicate: (
       options: SelectOption[],
       externalOptions: SelectOption[],

--- a/frontend/src/profiles/form-field-helper.ts
+++ b/frontend/src/profiles/form-field-helper.ts
@@ -20,7 +20,6 @@
 import { FormlyFieldConfig } from "@ngx-formly/core";
 import { Observable } from "rxjs";
 import {
-  ExternalCodelistResult,
   SelectOption,
   SelectOptionUi,
 } from "../app/services/codelist/codelist.service";
@@ -129,7 +128,7 @@ export interface RepeatListOptions extends Options {
     fetchCodelist: (
       query: string,
       page: number,
-    ) => Observable<ExternalCodelistResult>;
+    ) => Observable<PagedSearchResult>;
     deduplicate: (
       options: SelectOption[],
       externalOptions: SelectOption[],

--- a/frontend/src/profiles/ingrid/doctypes/ingrid-shared.ts
+++ b/frontend/src/profiles/ingrid/doctypes/ingrid-shared.ts
@@ -946,7 +946,7 @@ export abstract class IngridShared extends BaseDoctype {
                 this.options.dynamicRequired.spatialReferences(field),
             },
           }),
-          this.addRepeatList(
+          this.addExtendedRepeatList(
             "spatialSystems",
             this.transloco.translate("form.spatial.spatialSystems"),
             {
@@ -956,6 +956,9 @@ export abstract class IngridShared extends BaseDoctype {
                 "100",
                 "spatial.spatialSystems",
               ),
+              restCall: (query: string) =>
+                this.getExternalCodelistForSelect("EPSG", query),
+              externalOptionsThreshold: 3,
               codelistId: "100",
               expressions: {
                 "props.required": (field: FormlyFieldConfig) =>

--- a/frontend/src/profiles/ingrid/doctypes/ingrid-shared.ts
+++ b/frontend/src/profiles/ingrid/doctypes/ingrid-shared.ts
@@ -960,11 +960,11 @@ export abstract class IngridShared extends BaseDoctype {
                 codelistCall: (query: string) =>
                   this.getExternalCodelistForSelect("EPSG", query),
                 deduplicate: (options, externalOptions) => {
-                  const localLabels = options.map((r) => r.label.toLowerCase());
+                  const localLabels = options.map((r) => r.label.split(":")[0]);
                   return [
                     ...options,
                     ...externalOptions.filter(
-                      (r) => !localLabels.includes(r.label.toLowerCase()),
+                      (r) => !localLabels.includes(r.label.split(":")[0]),
                     ),
                   ];
                 },

--- a/frontend/src/profiles/ingrid/doctypes/ingrid-shared.ts
+++ b/frontend/src/profiles/ingrid/doctypes/ingrid-shared.ts
@@ -957,8 +957,8 @@ export abstract class IngridShared extends BaseDoctype {
                 "spatial.spatialSystems",
               ),
               externalOptions: {
-                codelistCall: (query: string) =>
-                  this.getExternalCodelistForSelect("EPSG", query),
+                fetchCodelist: (query: string, page: number) =>
+                  this.getExternalCodelistForSelect("EPSG", query, page),
                 deduplicate: (options, externalOptions) => {
                   const localLabels = options.map((r) => r.label.split(":")[0]);
                   return [

--- a/frontend/src/profiles/ingrid/doctypes/ingrid-shared.ts
+++ b/frontend/src/profiles/ingrid/doctypes/ingrid-shared.ts
@@ -956,9 +956,20 @@ export abstract class IngridShared extends BaseDoctype {
                 "100",
                 "spatial.spatialSystems",
               ),
-              restCall: (query: string) =>
-                this.getExternalCodelistForSelect("EPSG", query),
-              externalOptionsThreshold: 3,
+              externalOptions: {
+                codelistCall: (query: string) =>
+                  this.getExternalCodelistForSelect("EPSG", query),
+                deduplicate: (options, externalOptions) => {
+                  const localLabels = options.map((r) => r.label.toLowerCase());
+                  return [
+                    ...options,
+                    ...externalOptions.filter(
+                      (r) => !localLabels.includes(r.label.toLowerCase()),
+                    ),
+                  ];
+                },
+                threshold: 3,
+              },
               codelistId: "100",
               expressions: {
                 "props.required": (field: FormlyFieldConfig) =>

--- a/server/src/main/java/de/ingrid/igeserver/api/CodelistApi.kt
+++ b/server/src/main/java/de/ingrid/igeserver/api/CodelistApi.kt
@@ -21,6 +21,7 @@ package de.ingrid.igeserver.api
 
 import de.ingrid.codelists.model.CodeList
 import de.ingrid.igeserver.persistence.postgresql.jpa.model.ige.Codelist
+import de.ingrid.igeserver.services.externalCodelistRepository.PagedSearchResult
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -35,6 +36,7 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RequestParam
 import java.security.Principal
 
 @Hidden
@@ -88,5 +90,6 @@ interface CodelistApi {
     fun getExternalCodelist(
         @Parameter() @PathVariable id: String,
         @Parameter() @PathVariable filter: String,
-    ): ResponseEntity<List<String>>
+        @Parameter() @RequestParam page: Int,
+    ): ResponseEntity<PagedSearchResult>
 }

--- a/server/src/main/java/de/ingrid/igeserver/api/CodelistApi.kt
+++ b/server/src/main/java/de/ingrid/igeserver/api/CodelistApi.kt
@@ -82,4 +82,11 @@ interface CodelistApi {
         @Parameter() @PathVariable id: String,
         @Parameter() @RequestBody favorites: List<String>?,
     ): ResponseEntity<Unit>
+
+    @Operation
+    @GetMapping(value = ["/external/{id}/{filter}"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun getExternalCodelist(
+        @Parameter() @PathVariable id: String,
+        @Parameter() @PathVariable filter: String,
+    ): ResponseEntity<List<String>>
 }

--- a/server/src/main/java/de/ingrid/igeserver/api/CodelistApiController.kt
+++ b/server/src/main/java/de/ingrid/igeserver/api/CodelistApiController.kt
@@ -25,6 +25,7 @@ import de.ingrid.igeserver.persistence.postgresql.jpa.model.ige.Codelist
 import de.ingrid.igeserver.services.CatalogService
 import de.ingrid.igeserver.services.CodelistHandler
 import de.ingrid.igeserver.services.externalCodelistRepository.ExternalCodelistRepositoryFactory
+import de.ingrid.igeserver.services.externalCodelistRepository.PagedSearchResult
 import org.apache.logging.log4j.kotlin.logger
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
@@ -125,9 +126,9 @@ class CodelistApiController(
         return ResponseEntity.ok(codelists)
     }
 
-    override fun getExternalCodelist(id: String, filter: String): ResponseEntity<List<String>> {
+    override fun getExternalCodelist(id: String, filter: String, page: Int): ResponseEntity<PagedSearchResult> {
         val codelistRepo = externalCodelistRepositoryFactory.getRepository(id)
-        val values = codelistRepo.search(filter)
+        val values = codelistRepo.search(filter, page)
         return ResponseEntity.ok(values)
     }
 }

--- a/server/src/main/java/de/ingrid/igeserver/api/CodelistApiController.kt
+++ b/server/src/main/java/de/ingrid/igeserver/api/CodelistApiController.kt
@@ -35,7 +35,9 @@ import java.security.Principal
 
 @RestController
 @RequestMapping("/api/codelist")
-class CodelistApiController : CodelistApi {
+class CodelistApiController(
+    private val externalCodelistRepositoryFactory: ExternalCodelistRepositoryFactory,
+) : CodelistApi {
 
     private val log = logger()
 
@@ -124,7 +126,7 @@ class CodelistApiController : CodelistApi {
     }
 
     override fun getExternalCodelist(id: String, filter: String): ResponseEntity<List<String>> {
-        val codelistRepo = ExternalCodelistRepositoryFactory.getRepository(id)
+        val codelistRepo = externalCodelistRepositoryFactory.getRepository(id)
         val values = codelistRepo.search(filter)
         return ResponseEntity.ok(values)
     }

--- a/server/src/main/java/de/ingrid/igeserver/api/CodelistApiController.kt
+++ b/server/src/main/java/de/ingrid/igeserver/api/CodelistApiController.kt
@@ -24,6 +24,7 @@ import de.ingrid.igeserver.ServerException
 import de.ingrid.igeserver.persistence.postgresql.jpa.model.ige.Codelist
 import de.ingrid.igeserver.services.CatalogService
 import de.ingrid.igeserver.services.CodelistHandler
+import de.ingrid.igeserver.services.externalCodelistRepository.ExternalCodelistRepositoryFactory
 import org.apache.logging.log4j.kotlin.logger
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
@@ -120,5 +121,11 @@ class CodelistApiController : CodelistApi {
     override fun updateCodelists(): ResponseEntity<List<CodeList>> {
         val codelists = handler.fetchCodelists() ?: throw ServerException.withReason("Failed to synchronize code lists")
         return ResponseEntity.ok(codelists)
+    }
+
+    override fun getExternalCodelist(id: String, filter: String): ResponseEntity<List<String>> {
+        val codelistRepo = ExternalCodelistRepositoryFactory.getRepository(id)
+        val values = codelistRepo.search(filter)
+        return ResponseEntity.ok(values)
     }
 }

--- a/server/src/main/java/de/ingrid/igeserver/configuration/CacheConfiguration.kt
+++ b/server/src/main/java/de/ingrid/igeserver/configuration/CacheConfiguration.kt
@@ -47,6 +47,12 @@ class CacheConfiguration {
                 .expireAfterWrite(Duration.ofDays(1)).maximumSize(200).build(),
         )
 
+        cacheManager.registerCustomCache(
+            "epsgCodelistCache",
+            Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofDays(1)).maximumSize(200).build(),
+        )
+
         cacheManager.registerCustomCache("aclCache", Caffeine.newBuilder().build())
 
         return cacheManager

--- a/server/src/main/java/de/ingrid/igeserver/services/externalCodelistRepository/ExternalCodelistRepository.kt
+++ b/server/src/main/java/de/ingrid/igeserver/services/externalCodelistRepository/ExternalCodelistRepository.kt
@@ -19,10 +19,25 @@
  */
 package de.ingrid.igeserver.services.externalCodelistRepository
 
+data class PagedSearchResult(
+    val page: Int,
+    val totalPages: Int,
+    val results: List<String>,
+) {
+    companion object {
+        val EMPTY = PagedSearchResult(
+            page = 0,
+            totalPages = 0,
+            results = emptyList(),
+        )
+    }
+}
+
 interface ExternalCodelistRepository {
     /**
      * @param term The search term.
+     * @param page The search results page that should be returned.
      * @return A list of string representations of found items
      */
-    fun search(term: String): List<String>
+    fun search(term: String, page: Int = 0): PagedSearchResult
 }

--- a/server/src/main/java/de/ingrid/igeserver/services/externalCodelistRepository/ExternalCodelistRepository.kt
+++ b/server/src/main/java/de/ingrid/igeserver/services/externalCodelistRepository/ExternalCodelistRepository.kt
@@ -1,0 +1,28 @@
+/**
+ * ==================================================
+ * Copyright (C) 2023-2025 wemove digital solutions GmbH
+ * ==================================================
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be
+ * approved by the European Commission - subsequent versions of the
+ * EUPL (the "Licence");
+ *
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package de.ingrid.igeserver.services.externalCodelistRepository
+
+interface ExternalCodelistRepository {
+    /**
+     * @param term The search term.
+     * @return A list of string representations of found items
+     */
+    fun search(term: String): List<String>
+}

--- a/server/src/main/java/de/ingrid/igeserver/services/externalCodelistRepository/ExternalCodelistRepositoryFactory.kt
+++ b/server/src/main/java/de/ingrid/igeserver/services/externalCodelistRepository/ExternalCodelistRepositoryFactory.kt
@@ -19,11 +19,12 @@
  */
 package de.ingrid.igeserver.services.externalCodelistRepository
 
-import de.ingrid.igeserver.services.externalCodelistRepository.repositories.EpsgRepository
+import org.springframework.stereotype.Service
 
-object ExternalCodelistRepositoryFactory {
-    fun getRepository(repositoryId: String): ExternalCodelistRepository = when (repositoryId) {
-        "EPSG" -> EpsgRepository()
-        else -> throw IllegalArgumentException("Unknown repository ID: $repositoryId")
-    }
+@Service
+class ExternalCodelistRepositoryFactory(
+    private val repositories: Map<String, ExternalCodelistRepository>,
+) {
+    fun getRepository(repositoryId: String): ExternalCodelistRepository = repositories[repositoryId]
+        ?: throw IllegalArgumentException("Unknown repository ID: $repositoryId")
 }

--- a/server/src/main/java/de/ingrid/igeserver/services/externalCodelistRepository/ExternalCodelistRepositoryFactory.kt
+++ b/server/src/main/java/de/ingrid/igeserver/services/externalCodelistRepository/ExternalCodelistRepositoryFactory.kt
@@ -1,0 +1,29 @@
+/**
+ * ==================================================
+ * Copyright (C) 2023-2025 wemove digital solutions GmbH
+ * ==================================================
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be
+ * approved by the European Commission - subsequent versions of the
+ * EUPL (the "Licence");
+ *
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package de.ingrid.igeserver.services.externalCodelistRepository
+
+import de.ingrid.igeserver.services.externalCodelistRepository.repositories.EpsgRepository
+
+object ExternalCodelistRepositoryFactory {
+    fun getRepository(repositoryId: String): ExternalCodelistRepository = when (repositoryId) {
+        "EPSG" -> EpsgRepository()
+        else -> throw IllegalArgumentException("Unknown repository ID: $repositoryId")
+    }
+}

--- a/server/src/main/java/de/ingrid/igeserver/services/externalCodelistRepository/repositories/EpsgRepository.kt
+++ b/server/src/main/java/de/ingrid/igeserver/services/externalCodelistRepository/repositories/EpsgRepository.kt
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import de.ingrid.igeserver.services.externalCodelistRepository.ExternalCodelistRepository
 import org.apache.logging.log4j.kotlin.logger
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
 import java.io.InputStream
 import java.net.URI
 import java.net.http.HttpClient
@@ -45,6 +46,7 @@ data class EpsgCodelistEntry(
     val Name: String,
 )
 
+@Service("EPSG")
 open class EpsgRepository : ExternalCodelistRepository {
 
     private val log = logger()

--- a/server/src/main/java/de/ingrid/igeserver/services/externalCodelistRepository/repositories/EpsgRepository.kt
+++ b/server/src/main/java/de/ingrid/igeserver/services/externalCodelistRepository/repositories/EpsgRepository.kt
@@ -23,11 +23,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import de.ingrid.igeserver.services.externalCodelistRepository.ExternalCodelistRepository
+import de.ingrid.igeserver.services.externalCodelistRepository.PagedSearchResult
 import org.apache.logging.log4j.kotlin.logger
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
+import org.springframework.web.util.UriComponentsBuilder
 import java.io.InputStream
-import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
@@ -38,6 +39,9 @@ import java.util.concurrent.Executors
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class EpsgApiResponse(
     val Results: List<EpsgCodelistEntry>,
+    val Page: Int,
+    val PageSize: Int,
+    val TotalResults: Int,
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -51,31 +55,37 @@ open class EpsgRepository : ExternalCodelistRepository {
 
     private val log = logger()
     private val mapper = jacksonObjectMapper()
-    private val url = "https://apps.epsg.org/api/v1/CoordRefSystem?keywords="
+    private val url = "https://apps.epsg.org/api/v1/CoordRefSystem"
 
     /**
      * Searches the EPSG API for a term and returns a List of string representations of EPSG Codes.
      */
-    @Cacheable(value = ["epsgCodelistCache"], key = "#term")
-    override fun search(term: String): List<String> {
-        val searchUrl = "$url$term*"
+    @Cacheable(value = ["epsgCodelistCache"], key = "{ #term, #page }")
+    override fun search(term: String, page: Int): PagedSearchResult {
+        val params = mapOf(
+            "keywords" to "$term*",
+            "page" to page.toString(),
+        )
 
         try {
-            val inputStream: InputStream = sendRequest("GET", searchUrl) ?: return emptyList()
+            val inputStream: InputStream = sendRequest("GET", this.url, params) ?: return PagedSearchResult.EMPTY
             val jsonString = inputStream.bufferedReader().use { it.readText() }
             val apiResponse = mapper.readValue<EpsgApiResponse>(jsonString)
-            return apiResponse.Results.map { "EPSG ${it.Code}: ${it.Name}" }
+            return PagedSearchResult(
+                apiResponse.Page,
+                (apiResponse.TotalResults + apiResponse.PageSize - 1) / apiResponse.PageSize,
+                apiResponse.Results.map { "EPSG ${it.Code}: ${it.Name}" },
+            )
         } catch (e: Exception) {
             log.warn("Error searching EPSG: ${e.message}")
-            return emptyList()
+            return PagedSearchResult.EMPTY
         }
     }
 
-    private fun sendRequest(method: String, url: String, body: String? = null): InputStream {
+    private fun sendRequest(method: String, url: String, params: Map<String, Any>, body: String? = null): InputStream {
         val executor = Executors.newSingleThreadExecutor()
-        val request = httpRequest(method, url, body)
+        val request = httpRequest(method, url, params, body)
         val http = httpClient(executor)
-
         return http.send(request, HttpResponse.BodyHandlers.ofInputStream()).body()
     }
 
@@ -85,12 +95,15 @@ open class EpsgRepository : ExternalCodelistRepository {
         .executor(executor)
         .build()
 
-    private fun httpRequest(method: String, url: String, body: String?): HttpRequest {
+    private fun httpRequest(method: String, url: String, params: Map<String, Any>, body: String?): HttpRequest {
         val msgBody =
             if (body == null) HttpRequest.BodyPublishers.noBody() else HttpRequest.BodyPublishers.ofString(body)
+        val fullURI = UriComponentsBuilder.fromUriString(url).apply {
+            params.forEach(this::queryParam)
+        }.build().toUri()
         return HttpRequest.newBuilder()
             .method(method, msgBody)
-            .uri(URI.create(url))
+            .uri(fullURI)
             .header("Content-Type", "application/json")
             .timeout(Duration.ofSeconds(60))
             .build()

--- a/server/src/main/java/de/ingrid/igeserver/services/externalCodelistRepository/repositories/EpsgRepository.kt
+++ b/server/src/main/java/de/ingrid/igeserver/services/externalCodelistRepository/repositories/EpsgRepository.kt
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import de.ingrid.igeserver.services.externalCodelistRepository.ExternalCodelistRepository
 import de.ingrid.igeserver.services.externalCodelistRepository.PagedSearchResult
 import org.apache.logging.log4j.kotlin.logger
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.web.util.UriComponentsBuilder
@@ -51,11 +52,12 @@ data class EpsgCodelistEntry(
 )
 
 @Service("EPSG")
-open class EpsgRepository : ExternalCodelistRepository {
+open class EpsgRepository(
+    @Value("\${codelist.external.epsgUrl}") val epsgUrl: String,
+) : ExternalCodelistRepository {
 
     private val log = logger()
     private val mapper = jacksonObjectMapper()
-    private val url = "https://apps.epsg.org/api/v1/CoordRefSystem"
 
     /**
      * Searches the EPSG API for a term and returns a List of string representations of EPSG Codes.
@@ -68,7 +70,7 @@ open class EpsgRepository : ExternalCodelistRepository {
         )
 
         try {
-            val inputStream: InputStream = sendRequest("GET", this.url, params) ?: return PagedSearchResult.EMPTY
+            val inputStream: InputStream = sendRequest("GET", this.epsgUrl, params) ?: return PagedSearchResult.EMPTY
             val jsonString = inputStream.bufferedReader().use { it.readText() }
             val apiResponse = mapper.readValue<EpsgApiResponse>(jsonString)
             return PagedSearchResult(

--- a/server/src/main/java/de/ingrid/igeserver/services/externalCodelistRepository/repositories/EpsgRepository.kt
+++ b/server/src/main/java/de/ingrid/igeserver/services/externalCodelistRepository/repositories/EpsgRepository.kt
@@ -1,0 +1,96 @@
+/**
+ * ==================================================
+ * Copyright (C) 2023-2025 wemove digital solutions GmbH
+ * ==================================================
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be
+ * approved by the European Commission - subsequent versions of the
+ * EUPL (the "Licence");
+ *
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package de.ingrid.igeserver.services.externalCodelistRepository.repositories
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import de.ingrid.igeserver.services.externalCodelistRepository.ExternalCodelistRepository
+import org.apache.logging.log4j.kotlin.logger
+import org.springframework.cache.annotation.Cacheable
+import java.io.InputStream
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class EpsgApiResponse(
+    val Results: List<EpsgCodelistEntry>,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class EpsgCodelistEntry(
+    val Code: Int,
+    val Name: String,
+)
+
+open class EpsgRepository : ExternalCodelistRepository {
+
+    private val log = logger()
+    private val mapper = jacksonObjectMapper()
+    private val url = "https://apps.epsg.org/api/v1/CoordRefSystem?keywords="
+
+    /**
+     * Searches the EPSG API for a term and returns a List of string representations of EPSG Codes.
+     */
+    @Cacheable(value = ["epsgCodelistCache"], key = "#term")
+    override fun search(term: String): List<String> {
+        val searchUrl = "$url$term*"
+
+        try {
+            val inputStream: InputStream = sendRequest("GET", searchUrl) ?: return emptyList()
+            val jsonString = inputStream.bufferedReader().use { it.readText() }
+            val apiResponse = mapper.readValue<EpsgApiResponse>(jsonString)
+            return apiResponse.Results.map { "EPSG ${it.Code}: ${it.Name}" }
+        } catch (e: Exception) {
+            log.warn("Error searching EPSG: ${e.message}")
+            return emptyList()
+        }
+    }
+
+    private fun sendRequest(method: String, url: String, body: String? = null): InputStream {
+        val executor = Executors.newSingleThreadExecutor()
+        val request = httpRequest(method, url, body)
+        val http = httpClient(executor)
+
+        return http.send(request, HttpResponse.BodyHandlers.ofInputStream()).body()
+    }
+
+    private fun httpClient(executor: ExecutorService?) = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(30))
+        .followRedirects(HttpClient.Redirect.NORMAL)
+        .executor(executor)
+        .build()
+
+    private fun httpRequest(method: String, url: String, body: String?): HttpRequest {
+        val msgBody =
+            if (body == null) HttpRequest.BodyPublishers.noBody() else HttpRequest.BodyPublishers.ofString(body)
+        return HttpRequest.newBuilder()
+            .method(method, msgBody)
+            .uri(URI.create(url))
+            .header("Content-Type", "application/json")
+            .timeout(Duration.ofSeconds(60))
+            .build()
+    }
+}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -144,6 +144,8 @@ codelist.userName=${CODELIST_REPO_USER:}
 codelist.password=${CODELIST_REPO_PASSWORD:}
 #codelist.data-path=codelists
 
+codelist.external.epsgUrl=https://apps.epsg.org/api/v1/CoordRefSystem
+
 # scheduler: second, minute, hour, day of month, month, day(s) of week
 cron.codelist.expression=0 */30 * * * *
 cron.publish.expression=0 30 0 * * *


### PR DESCRIPTION
* Backend:
  * neuer Endpoint `/external/{id}/{filter}` in Codelisten-API für Anfrage an externe Codeliste
  * Einführung `EpsgRepository` als Spezialfall des neuen `ExternalCodelistRepository `
  * Suchen werden gecachet
* Frontend:
  *  `repeat-list.component.ts` wurde erweitert, um im gleichen Feld interne und externe Codelisteneinträge anzeigen zu können
  * externe Codelisteneinträge werden automatisch beim scrollen automatisch seitenweise nachgeladen
  * Such-Resultate werden im Frontend gecachet für direkte Anzeige bei Erweiterung der Suchanfrage (z.B. "303" -> "3034")